### PR TITLE
Add Flux UNet 57-block extraction and layout-aware block display

### DIFF
--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -63,6 +63,20 @@ function sortLoras(items, mode) {
   return data;
 }
 
+function getBlockLabel(block, layout) {
+  const idx = block?.block_index ?? 0;
+
+  if (layout === "flux_unet_57") {
+    if (idx < 19) {
+      return `DOUBLE_${idx.toString().padStart(2, "0")}`;
+    }
+    const singleIndex = idx - 19;
+    return `SINGLE_${singleIndex.toString().padStart(2, "0")}`;
+  }
+
+  return `#${idx.toString().padStart(2, "0")}`;
+}
+
 function App() {
   const [baseModel, setBaseModel] = useState("FLX");
   const [category, setCategory] = useState("ALL");
@@ -521,6 +535,10 @@ function App() {
                       <dd>{selectedDetails.lora_type || "Unknown"}</dd>
                     </div>
                     <div className="lm-details-row">
+                      <dt>Block layout</dt>
+                      <dd>{selectedDetails.block_layout || blockData?.layout || "Unknown"}</dd>
+                    </div>
+                    <div className="lm-details-row">
                       <dt>Rank</dt>
                       <dd>{selectedDetails.rank ?? "Unknown"}</dd>
                     </div>
@@ -543,7 +561,7 @@ function App() {
                   <div className="lm-blocks-title">Block weights</div>
                   <div className="lm-blocks-count">
                     {blockData?.has_block_weights && blockData.blocks
-                      ? `${blockData.blocks.length} blocks`
+                      ? `${blockData.blocks.length} blocks${blockData.layout ? ` · ${blockData.layout}` : ""}`
                       : "No block weights"}
                   </div>
                 </div>
@@ -555,7 +573,7 @@ function App() {
                       {blockData.blocks.map((b) => (
                         <div className="lm-block-row" key={b.block_index}>
                           <div className="lm-block-index">
-                            #{b.block_index.toString().padStart(2, "0")}
+                            {getBlockLabel(b, blockData?.layout)}
                           </div>
                           <div className="lm-block-bar-wrap">
                             <div className="lm-block-bar-bg">

--- a/Database/backend/lora_api_server.py
+++ b/Database/backend/lora_api_server.py
@@ -218,6 +218,7 @@ def api_lora_search(
                 model_family,
                 lora_type,
                 rank,
+                block_layout,
                 has_block_weights,
                 created_at,
                 updated_at
@@ -325,7 +326,7 @@ def api_lora_blocks(stable_id: str):
 
         # Look up LoRA by stable_id first
         cur.execute(
-            "SELECT id, has_block_weights FROM lora WHERE stable_id = ?;",
+            "SELECT id, has_block_weights, block_layout FROM lora WHERE stable_id = ?;",
             (stable_id,),
         )
         row = cur.fetchone()
@@ -337,11 +338,13 @@ def api_lora_blocks(stable_id: str):
 
         lora_id = row["id"]
         has_blocks = bool(row["has_block_weights"])
+        layout = row["block_layout"]
 
         if not has_blocks:
             return {
                 "stable_id": stable_id,
                 "has_block_weights": False,
+                "layout": layout,
                 "blocks": [],
             }
 
@@ -370,6 +373,7 @@ def api_lora_blocks(stable_id: str):
         return {
             "stable_id": stable_id,
             "has_block_weights": bool(blocks),
+            "layout": layout,
             "blocks": blocks,
         }
     finally:


### PR DESCRIPTION
### Motivation
- Support Flux UNet-style LoRAs that use `lora_unet_double_blocks_<n>` and `lora_unet_single_blocks_<n>` keys so per-block strengths are extracted and shown instead of reporting "No block weights".
- Preserve existing transformer extraction and keep the new logic isolated to Flux UNet parsing.

### Description
- Updated `Database/backend/delta_inspector_engine.py` to detect `lora_unet_single_blocks_<idx>` keys, added `_compute_flux_unet_57_strengths`, compute an ordered 57-element vector `[DOUBLE_0..18] + [SINGLE_0..37]`, normalise strengths, and emit `block_layout: "flux_unet_57"` in the analysis output.
- Extended `LoraAnalysis` with a `block_layout` field and preserved existing transformer and TE-only flows (added `flux_transformer_38`, `flux_unet_double`, and `flux_te_layers` layout labels where appropriate).
- Persisted layout metadata in `Database/backend/lora_indexer.py` by adding a `block_layout` column to the `lora` table (with a lightweight migration), storing `block_layout` from analysis, and continuing to save per-block rows in `lora_block_weights` while keeping `has_block_weights` semantics.
- Updated API handlers in `Database/backend/lora_api_server.py` so `GET /api/lora/search` includes `block_layout` and `GET /api/lora/{stable_id}/blocks` returns `layout` alongside the `blocks` array.
- Updated the UI in `Database/UI/src/App.jsx` to display the `block_layout` in the LoRA details and to render block bars dynamically from `blocks.length`, including human-friendly `DOUBLE_xx`/`SINGLE_xx` labels for `flux_unet_57`.

### Testing
- Ran `python -m py_compile Database/backend/delta_inspector_engine.py Database/backend/lora_indexer.py Database/backend/lora_api_server.py` which completed successfully.
- Built the frontend with `npm run build` in `Database/UI` successfully and captured a UI screenshot of the updated details panel.
- Attempted a functional run that creates synthetic `.safetensors` and calls `inspect_lora`, but it could not complete in this environment because the `torch` module was not available, so full runtime parsing verification was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f1e6d25308321b7e1ea3954e72cb6)