### PR TITLE
Phase 5.1 polish: inline weight editing, unsaved-change flows, and UI cleanup

### DIFF
--- a/Database/UI/src/App.css
+++ b/Database/UI/src/App.css
@@ -649,9 +649,9 @@ option {
 
 .lm-details-grid {
   margin: 0;
-  padding: 8px 0 0 0;
+  padding: 4px 0 0 0;
   display: grid;
-  grid-template-columns: 90px minmax(0, 1fr);
+  grid-template-columns: 56px minmax(0, 1fr);
   row-gap: 8px;
   column-gap: 10px;
 }
@@ -688,6 +688,7 @@ option {
 
 .lm-details-meta {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   font-size: 11px;
   color: #9ca3af;
@@ -741,37 +742,6 @@ option {
   border-color: rgba(248, 113, 113, 0.8);
   background: rgba(248, 113, 113, 0.1);
   color: #fecaca;
-}
-
-/* ============================================
-   COPY BUTTON
-   ============================================ */
-
-.lm-copy-btn {
-  flex-shrink: 0;
-  border-radius: 6px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.7);
-  color: #94a3b8;
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
-}
-
-.lm-copy-btn:hover {
-  border-color: #22d3ee;
-  color: #e5e7eb;
-  background: rgba(34, 211, 238, 0.08);
-}
-
-.lm-copy-btn-done {
-  border-color: rgba(52, 211, 153, 0.7);
-  color: #6ee7b7;
-  background: rgba(52, 211, 153, 0.08);
 }
 
 /* ============================================
@@ -853,6 +823,10 @@ option {
   opacity: 0.85;
 }
 
+.lm-blocks-list-profile .lm-block-row {
+  border-bottom-color: rgba(45, 212, 191, 0.35);
+}
+
 .lm-block-row {
   display: grid;
   grid-template-columns: 40px minmax(0, 1fr) 64px;
@@ -897,6 +871,36 @@ option {
   font-variant-numeric: tabular-nums;
   font-size: 12px;
   min-width: 64px;
+}
+
+.lm-block-edit-button {
+  border: none;
+  background: transparent;
+  color: #e5e7eb;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+
+.lm-block-edit-button:hover {
+  background: rgba(34, 211, 238, 0.12);
+}
+
+.lm-block-edit-input {
+  width: 58px;
+  border-radius: 6px;
+  border: 1px solid rgba(45, 212, 191, 0.8);
+  background: rgba(2, 6, 23, 0.95);
+  color: #e5e7eb;
+  font-size: 12px;
+  padding: 2px 4px;
+  text-align: right;
+}
+
+.lm-block-row-profile {
+  background: rgba(45, 212, 191, 0.03);
 }
 
 .lm-blocks-empty {
@@ -978,10 +982,11 @@ option {
 
 .lm-profile-item-info {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 6px;
   min-width: 0;
   flex: 1;
+  overflow: hidden;
 }
 
 .lm-profile-item-name {
@@ -991,11 +996,13 @@ option {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 30ch;
 }
 
 .lm-profile-item-meta {
-  font-size: 10px;
+  font-size: 11px;
   color: #6b7280;
+  white-space: nowrap;
 }
 
 .lm-profile-item-actions {

--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -35,6 +35,28 @@ function classNames(...parts) {
   return parts.filter(Boolean).join(" ");
 }
 
+function clampWeight(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.min(2, Math.max(0, num));
+}
+
+function formatWeightValue(value) {
+  const clamped = clampWeight(value);
+  const fixed = (Math.round(clamped * 1000) / 1000).toFixed(3);
+  return fixed.replace(/\.?0+$/, "");
+}
+
+function formatDateOnly(value) {
+  if (!value) return "not recorded";
+  const asString = String(value);
+  const directMatch = asString.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (directMatch) return directMatch[1];
+  const parsed = new Date(asString);
+  if (Number.isNaN(parsed.getTime())) return "not recorded";
+  return parsed.toISOString().slice(0, 10);
+}
+
 const COMMON_LAYOUT_OPTIONS = ["flux_fallback_16", "flux_unet_57", "unet_57"];
 
 function formatLayoutLabel(layout) {
@@ -98,22 +120,6 @@ function getBlocksBadge(item) {
   return "NO BLKS";
 }
 
-function getDisplayBlockCount(item) {
-  const hasBlocks = Boolean(item?.has_block_weights);
-  const expected = getExpectedBlocksFromLayout(item?.block_layout);
-  if (hasBlocks) {
-    if (expected !== null) return `${expected} blocks`;
-    const actual = Number.isFinite(item?.block_count) ? item.block_count : null;
-    if (actual !== null) return `${actual} blocks`;
-    return "Blocks";
-  }
-  const baseCode = (item?.base_model_code || "").toUpperCase();
-  if ((baseCode === "FLX" || baseCode === "FLK") && item?.block_layout === "flux_fallback_16") {
-    return "16 blocks";
-  }
-  return "No blocks";
-}
-
 function sortLoras(items, mode) {
   const data = [...items];
   if (mode === "name_asc" || mode === "name_desc") {
@@ -158,34 +164,6 @@ function fallbackCopy(text) {
 }
 
 // =====================================================================
-// CopyButton component
-// =====================================================================
-function CopyButton({ text, label = "Copy" }) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef(null);
-
-  function handleCopy(e) {
-    e.stopPropagation();
-    copyToClipboard(text);
-    setCopied(true);
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setCopied(false), 1500);
-  }
-
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  return (
-    <button
-      className={classNames("lm-copy-btn", copied && "lm-copy-btn-done")}
-      onClick={handleCopy}
-      title={`Copy ${label}`}
-    >
-      {copied ? "Copied" : label}
-    </button>
-  );
-}
-
-// =====================================================================
 // Main App
 // =====================================================================
 function App() {
@@ -204,6 +182,11 @@ function App() {
   const [selectedStableId, setSelectedStableId] = useState(null);
   const [selectedDetails, setSelectedDetails] = useState(null);
   const [blockData, setBlockData] = useState(null);
+  const [originalBlockWeights, setOriginalBlockWeights] = useState(null);
+  const [loadedProfile, setLoadedProfile] = useState(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [editingBlockIndex, setEditingBlockIndex] = useState(null);
+  const [editingBlockValue, setEditingBlockValue] = useState("");
   const [detailsLoading, setDetailsLoading] = useState(false);
 
   const [sortMode, setSortMode] = useState("name_asc");
@@ -303,6 +286,11 @@ function App() {
       setSelectedStableId(null);
       setSelectedDetails(null);
       setBlockData(null);
+      setOriginalBlockWeights(null);
+      setLoadedProfile(null);
+      setHasUnsavedChanges(false);
+      setEditingBlockIndex(null);
+      setEditingBlockValue("");
       setProfiles([]);
 
       setCurrentPage(page);
@@ -313,19 +301,146 @@ function App() {
     }
   }
 
+  function applyDisplayedWeights(weights) {
+    setBlockData((prev) => {
+      if (!prev) return prev;
+      const nextBlocks = weights.map((weight, index) => ({
+        block_index: prev.blocks?.[index]?.block_index ?? index,
+        weight: clampWeight(weight),
+        raw_strength: prev.blocks?.[index]?.raw_strength ?? null,
+      }));
+      return { ...prev, blocks: nextBlocks, fallback: false, fallback_reason: null };
+    });
+  }
+
+  function getCurrentWeights() {
+    return Array.isArray(blockData?.blocks)
+      ? blockData.blocks.map((b) => clampWeight(b?.weight))
+      : [];
+  }
+
+  async function saveProfileToApi(stableId, profileName, weights) {
+    const res = await fetch(`${API_BASE}/lora/${stableId}/profiles`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile_name: profileName, block_weights: weights }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Save failed (${res.status})`);
+    }
+    return res.json();
+  }
+
+  async function updateProfileToApi(stableId, profileId, profileName, weights) {
+    const res = await fetch(`${API_BASE}/lora/${stableId}/profiles/${profileId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile_name: profileName, block_weights: weights }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Update failed (${res.status})`);
+    }
+    return res.json();
+  }
+
+  async function runWithUnsavedGuard(action) {
+    if (!hasUnsavedChanges || !selectedStableId) {
+      await action();
+      return;
+    }
+
+    const currentWeights = getCurrentWeights();
+
+    if (!loadedProfile) {
+      const saveAsNew = window.confirm("You have unsaved block weight changes. Save as a new profile?");
+      if (saveAsNew) {
+        const profileName = window.prompt("Enter a name for the new profile:", newProfileName || "");
+        if (!profileName || !profileName.trim()) return;
+        try {
+          await saveProfileToApi(selectedStableId, profileName.trim(), currentWeights);
+          await loadProfiles(selectedStableId);
+          setHasUnsavedChanges(false);
+          await action();
+        } catch (err) {
+          window.alert(err.message || "Failed to save profile.");
+        }
+        return;
+      }
+
+      if (Array.isArray(originalBlockWeights)) {
+        applyDisplayedWeights(originalBlockWeights);
+      }
+      setHasUnsavedChanges(false);
+      await action();
+      return;
+    }
+
+    const updateExisting = window.confirm(
+      `You have unsaved changes for loaded profile: "${loadedProfile.profile_name}". Update this profile? (Cancel = Save as new / Discard)`
+    );
+    if (updateExisting) {
+      try {
+        await updateProfileToApi(selectedStableId, loadedProfile.id, loadedProfile.profile_name, currentWeights);
+        setLoadedProfile((prev) => (prev ? { ...prev, block_weights: [...currentWeights] } : prev));
+        setHasUnsavedChanges(false);
+        await loadProfiles(selectedStableId);
+        await action();
+      } catch (err) {
+        window.alert(err.message || "Failed to update profile.");
+      }
+      return;
+    }
+
+    const saveAsNew = window.confirm("Save changes as a NEW profile?");
+    if (saveAsNew) {
+      const profileName = window.prompt("Enter a name for the new profile:", newProfileName || "");
+      if (!profileName || !profileName.trim()) return;
+      try {
+        await saveProfileToApi(selectedStableId, profileName.trim(), currentWeights);
+        await loadProfiles(selectedStableId);
+        setHasUnsavedChanges(false);
+        await action();
+      } catch (err) {
+        window.alert(err.message || "Failed to save profile.");
+      }
+      return;
+    }
+
+    if (Array.isArray(loadedProfile.block_weights)) {
+      applyDisplayedWeights(loadedProfile.block_weights);
+    }
+    setHasUnsavedChanges(false);
+    await action();
+  }
+
   function handlePageChange(newPage) {
     if (newPage < 0 || newPage >= totalPages) return;
-    runSearch(newPage);
+    runWithUnsavedGuard(() => runSearch(newPage));
   }
 
   async function handleCardClick(item) {
     if (!item?.stable_id) return;
     const stableId = item.stable_id;
 
+    if (stableId !== selectedStableId) {
+      let cancelled = true;
+      await runWithUnsavedGuard(async () => {
+        cancelled = false;
+      });
+      if (cancelled) return;
+    }
+
     try {
       setSelectedStableId(stableId);
       setSelectedDetails(null);
       setBlockData(null);
+      setOriginalBlockWeights(null);
+      setLoadedProfile(null);
+      setHasUnsavedChanges(false);
+      setEditingBlockIndex(null);
+      setEditingBlockValue("");
       setDetailsLoading(true);
       setProfiles([]);
 
@@ -342,8 +457,14 @@ function App() {
       if (blocksRes.ok) {
         const blocksJson = await blocksRes.json();
         setBlockData(blocksJson);
+        setOriginalBlockWeights(
+          Array.isArray(blocksJson?.blocks)
+            ? blocksJson.blocks.map((b) => clampWeight(b?.weight))
+            : null
+        );
       } else {
         setBlockData(null);
+        setOriginalBlockWeights(null);
       }
 
       // Load user profiles
@@ -378,7 +499,7 @@ function App() {
 
     try {
       setSavingProfile(true);
-      const weights = blockData.blocks.map((b) => Number(b.weight) || 0);
+      const weights = blockData.blocks.map((b) => clampWeight(b.weight));
 
       // Validate block weights (0.0 - 2.0 range)
       const invalidWeights = weights.filter((w) => w < 0.0 || w > 2.0);
@@ -386,15 +507,7 @@ function App() {
         throw new Error(`Invalid block weights detected. All weights must be between 0.0 and 2.0. Found ${invalidWeights.length} invalid value(s).`);
       }
 
-      const res = await fetch(`${API_BASE}/lora/${selectedStableId}/profiles`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ profile_name: name, block_weights: weights }),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `Save failed (${res.status})`);
-      }
+      await saveProfileToApi(selectedStableId, name, weights);
       setNewProfileName("");
       loadProfiles(selectedStableId);
     } catch (err) {
@@ -415,12 +528,19 @@ function App() {
         if (!prev) return prev;
         const newBlocks = profile.block_weights.map((w, i) => ({
           block_index: i,
-          weight: w,
+          weight: clampWeight(w),
           raw_strength: prev.blocks?.[i]?.raw_strength ?? null,
         }));
         return { ...prev, blocks: newBlocks, fallback: false, fallback_reason: null };
       });
     }
+
+    setLoadedProfile({
+      id: profile.id,
+      profile_name: profile.profile_name,
+      block_weights: (profile.block_weights || []).map((w) => clampWeight(w)),
+    });
+    setHasUnsavedChanges(false);
   }
 
   async function handleUpdateProfile() {
@@ -430,7 +550,7 @@ function App() {
 
     try {
       setSavingProfile(true);
-      const weights = blockData.blocks.map((b) => Number(b.weight) || 0);
+      const weights = blockData.blocks.map((b) => clampWeight(b.weight));
 
       // Validate block weights (0.0 - 2.0 range)
       const invalidWeights = weights.filter((w) => w < 0.0 || w > 2.0);
@@ -438,17 +558,13 @@ function App() {
         throw new Error(`Invalid block weights detected. All weights must be between 0.0 and 2.0. Found ${invalidWeights.length} invalid value(s).`);
       }
 
-      const res = await fetch(`${API_BASE}/lora/${selectedStableId}/profiles/${editingProfileId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ profile_name: name, block_weights: weights }),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `Update failed (${res.status})`);
-      }
+      await updateProfileToApi(selectedStableId, editingProfileId, name, weights);
       setEditingProfileId(null);
       setEditingProfileName("");
+      if (loadedProfile?.id === editingProfileId) {
+        setLoadedProfile((prev) => (prev ? { ...prev, profile_name: name, block_weights: [...weights] } : prev));
+      }
+      setHasUnsavedChanges(false);
       loadProfiles(selectedStableId);
     } catch (err) {
       setErrorMsg(err.message || "Failed to update profile");
@@ -494,20 +610,20 @@ function App() {
       return;
     }
 
-    setBlockData((prev) => {
-      if (!prev) return prev;
-      const newBlocks = profile.block_weights.map((w, i) => ({
-        block_index: i,
-        weight: w,
-        raw_strength: prev.blocks?.[i]?.raw_strength ?? null,
-      }));
-      return { ...prev, blocks: newBlocks, fallback: false, fallback_reason: null };
+    applyDisplayedWeights(profile.block_weights);
+    setLoadedProfile({
+      id: profile.id,
+      profile_name: profile.profile_name || "Unnamed profile",
+      block_weights: profile.block_weights.map((w) => clampWeight(w)),
     });
+    setHasUnsavedChanges(false);
+    setEditingBlockIndex(null);
+    setEditingBlockValue("");
   }
 
-  function handleSearchSubmit(e) {
+  async function handleSearchSubmit(e) {
     e.preventDefault();
-    runSearch(0);
+    await runWithUnsavedGuard(() => runSearch(0));
   }
 
   async function handleFullRescan() {
@@ -549,26 +665,73 @@ function App() {
     if (!blockData?.blocks?.length) return;
 
     setCopyWeightsStatus("copying");
-    const weightsStr = blockData.blocks.map((b) => Number(b.weight).toFixed(3)).join(",");
+    const weightsStr = blockData.blocks.map((b) => formatWeightValue(b.weight)).join(",");
 
     try {
       await copyToClipboard(weightsStr);
       setCopyWeightsStatus("copied");
       setTimeout(() => setCopyWeightsStatus("idle"), 2000);
-    } catch (err) {
+    } catch {
       setCopyWeightsStatus("failed");
       setTimeout(() => setCopyWeightsStatus("idle"), 2000);
     }
   }
 
+  function startWeightEdit(blockIndex, value) {
+    setEditingBlockIndex(blockIndex);
+    setEditingBlockValue(formatWeightValue(value));
+  }
+
+  function commitWeightEdit(blockIndex) {
+    if (!editingBlockValue.trim()) {
+      setEditingBlockIndex(null);
+      setEditingBlockValue("");
+      return;
+    }
+
+    const parsed = Number(editingBlockValue);
+    if (!Number.isFinite(parsed)) {
+      setEditingBlockIndex(null);
+      setEditingBlockValue("");
+      return;
+    }
+
+    const clamped = clampWeight(parsed);
+    setBlockData((prev) => {
+      if (!prev?.blocks) return prev;
+      const nextBlocks = prev.blocks.map((block) =>
+        block.block_index === blockIndex ? { ...block, weight: clamped } : block
+      );
+      return { ...prev, blocks: nextBlocks };
+    });
+    setHasUnsavedChanges(true);
+    setEditingBlockIndex(null);
+    setEditingBlockValue("");
+  }
+
+  function handleWeightInputChange(nextValue) {
+    if (/^(?:\d{0,1}(?:\.\d*)?|2(?:\.0*)?|)$/.test(nextValue)) {
+      setEditingBlockValue(nextValue);
+    }
+  }
+
+  function handleRevertToOriginal() {
+    if (!Array.isArray(originalBlockWeights)) return;
+    applyDisplayedWeights(originalBlockWeights);
+    setLoadedProfile(null);
+    setHasUnsavedChanges(false);
+    setEditingBlockIndex(null);
+    setEditingBlockValue("");
+  }
+
   const sortedResults = sortLoras(results, sortMode);
-  const layoutOptions = useMemo(() => {
-    const fromResults = results
+  const layoutOptions = useMemo(() => [...new Set([
+    ...COMMON_LAYOUT_OPTIONS,
+    ...results
       .map((item) => item?.block_layout)
       .filter((layout) => typeof layout === "string" && layout.trim().length > 0)
-      .map((layout) => layout.trim().toLowerCase());
-    return [...new Set([...COMMON_LAYOUT_OPTIONS, ...fromResults])];
-  }, [results]);
+      .map((layout) => layout.trim().toLowerCase()),
+  ])], [results]);
 
   useEffect(() => {
     if (layoutFilter === "ALL_LAYOUTS") return;
@@ -606,31 +769,57 @@ function App() {
         <form className="lm-filters" onSubmit={handleSearchSubmit}>
           <div className="lm-filter-group">
             <label className="lm-filter-label" htmlFor="base-model">Base model</label>
-            <select id="base-model" className="lm-select" value={baseModel} onChange={(e) => setBaseModel(e.target.value)}>
+            <select
+              id="base-model"
+              className="lm-select"
+              value={baseModel}
+              onChange={(e) => runWithUnsavedGuard(async () => setBaseModel(e.target.value))}
+            >
               {BASE_MODELS.map((m) => <option key={m.code} value={m.code}>{m.label}</option>)}
             </select>
           </div>
 
           <div className="lm-filter-group">
             <label className="lm-filter-label" htmlFor="category">Category</label>
-            <select id="category" className="lm-select" value={category} onChange={(e) => setCategory(e.target.value)}>
+            <select
+              id="category"
+              className="lm-select"
+              value={category}
+              onChange={(e) => runWithUnsavedGuard(async () => setCategory(e.target.value))}
+            >
               {CATEGORIES.map((c) => <option key={c.code} value={c.code}>{c.label}</option>)}
             </select>
           </div>
 
           <div className="lm-filter-group">
             <label className="lm-filter-label" htmlFor="search">Search</label>
-            <input id="search" className="lm-input" type="text" placeholder="Filename contains..." value={search} onChange={(e) => setSearch(e.target.value)} />
+            <input
+              id="search"
+              className="lm-input"
+              type="text"
+              placeholder="Filename contains..."
+              value={search}
+              onChange={(e) => runWithUnsavedGuard(async () => setSearch(e.target.value))}
+            />
           </div>
 
           <label className="lm-checkbox-row">
-            <input type="checkbox" checked={onlyBlocks} onChange={(e) => setOnlyBlocks(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={onlyBlocks}
+              onChange={(e) => runWithUnsavedGuard(async () => setOnlyBlocks(e.target.checked))}
+            />
             <span>Only LoRAs with block weights</span>
           </label>
 
           <div className="lm-filter-group">
             <label className="lm-filter-label" htmlFor="layout-filter">Block layout</label>
-            <select id="layout-filter" className="lm-select" value={layoutFilter} onChange={(e) => setLayoutFilter(e.target.value)}>
+            <select
+              id="layout-filter"
+              className="lm-select"
+              value={layoutFilter}
+              onChange={(e) => runWithUnsavedGuard(async () => setLayoutFilter(e.target.value))}
+            >
               <option value="ALL_LAYOUTS">All layouts</option>
               {layoutOptions.map((layout) => <option key={layout} value={layout}>{formatLayoutLabel(layout)}</option>)}
             </select>
@@ -644,8 +833,10 @@ function App() {
               value={sortMode}
               onChange={(e) => {
                 const mode = e.target.value;
-                setSortMode(mode);
-                setResults((prev) => sortLoras(prev, mode));
+                runWithUnsavedGuard(async () => {
+                  setSortMode(mode);
+                  setResults((prev) => sortLoras(prev, mode));
+                });
               }}
             >
               <option value="name_asc">Name &middot; A &rarr; Z</option>
@@ -810,7 +1001,6 @@ function App() {
                   <div className="lm-details-id-stack">
                     <div className="lm-details-stable-id-row">
                       <div className="lm-details-stable-id">{selectedDetails.stable_id}</div>
-                      <CopyButton text={selectedDetails.stable_id} label="ID" />
                     </div>
                     <div className="lm-details-lora-type-pill">{getLoraTypeLabel(selectedDetails)}</div>
                   </div>
@@ -824,37 +1014,15 @@ function App() {
               {!detailsLoading && selectedDetails && (
                 <>
                   <dl className="lm-details-grid">
-                    <dt>Filename</dt>
-                    <dd>
-                      <span>{selectedDetails.filename}</span>
-                      <CopyButton text={selectedDetails.filename} label="Name" />
-                    </dd>
-
-                    <dt>Base model</dt>
-                    <dd>{selectedDetails.base_model_code} &middot; {selectedDetails.base_model_name}</dd>
-
-                    <dt>Category</dt>
-                    <dd>{selectedDetails.category_code} &middot; {selectedDetails.category_name}</dd>
-
-                    <dt>Family</dt>
-                    <dd>{selectedDetails.model_family || "Unknown"}</dd>
-
-                    <dt>LoRA type</dt>
-                    <dd>{getLoraTypeLabel(selectedDetails)}</dd>
-
-                    <dt>Rank</dt>
-                    <dd>{selectedDetails.rank ?? "Unknown"}</dd>
-
                     <dt>Path</dt>
                     <dd className="lm-dd-path">
                       <span title={selectedDetails.file_path}>{selectedDetails.file_path}</span>
-                      <CopyButton text={selectedDetails.file_path} label="Path" />
                     </dd>
                   </dl>
 
                   <div className="lm-details-meta">
-                    <span>Created: {selectedDetails.created_at || "not recorded"}</span>
-                    <span>Updated: {selectedDetails.updated_at || "not recorded"}</span>
+                    <span>Created: {formatDateOnly(selectedDetails.created_at)}</span>
+                    <span>Updated: {formatDateOnly(selectedDetails.updated_at)}</span>
                   </div>
 
                   {/* Action buttons row */}
@@ -882,7 +1050,16 @@ function App() {
               <div className="lm-blocks-panel">
                 <div className="lm-blocks-header">
                   <div className="lm-blocks-title-row">
-                    <div className="lm-blocks-title">Block weights</div>
+                    <div className="lm-blocks-title">
+                      {loadedProfile
+                        ? `BLOCK WEIGHTS (PROFILE: "${loadedProfile.profile_name}")`
+                        : "BLOCK WEIGHTS"}
+                    </div>
+                    {loadedProfile && (
+                      <button className="lm-action-btn lm-action-btn-sm" onClick={handleRevertToOriginal}>
+                        Revert to Original
+                      </button>
+                    )}
                     {isFallbackBlocks && (
                       <span className="lm-fallback-badge" title={fallbackReason}>FALLBACK</span>
                     )}
@@ -897,9 +1074,9 @@ function App() {
                 )}
 
                 {hasAnyBlocks && (
-                  <div className={classNames("lm-blocks-list", isFallbackBlocks && "lm-blocks-list-fallback")}>
+                  <div className={classNames("lm-blocks-list", isFallbackBlocks && "lm-blocks-list-fallback", loadedProfile && "lm-blocks-list-profile")}>
                     {blockData.blocks.map((b) => (
-                      <div className={classNames("lm-block-row", isFallbackBlocks && "lm-block-row-fallback")} key={b.block_index}>
+                      <div className={classNames("lm-block-row", isFallbackBlocks && "lm-block-row-fallback", loadedProfile && "lm-block-row-profile")} key={b.block_index}>
                         <div className="lm-block-index">#{String(b.block_index ?? 0).padStart(2, "0")}</div>
                         <div className="lm-block-bar-wrap">
                           <div className="lm-block-bar-track">
@@ -909,7 +1086,32 @@ function App() {
                             />
                           </div>
                         </div>
-                        <div className="lm-block-value">{(Number(b.weight) || 0).toFixed(3)}</div>
+                        <div className="lm-block-value">
+                          {editingBlockIndex === b.block_index ? (
+                            <input
+                              className="lm-block-edit-input"
+                              value={editingBlockValue}
+                              autoFocus
+                              onChange={(e) => handleWeightInputChange(e.target.value)}
+                              onBlur={() => commitWeightEdit(b.block_index)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") commitWeightEdit(b.block_index);
+                                if (e.key === "Escape") {
+                                  setEditingBlockIndex(null);
+                                  setEditingBlockValue("");
+                                }
+                              }}
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              className="lm-block-edit-button"
+                              onClick={() => startWeightEdit(b.block_index, b.weight)}
+                            >
+                              {formatWeightValue(b.weight)}
+                            </button>
+                          )}
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -983,11 +1185,11 @@ function App() {
                     <div className="lm-profile-list">
                       {profiles.map((p) => (
                         <div className="lm-profile-item" key={p.id}>
-                          <div className="lm-profile-item-info">
-                            <div className="lm-profile-item-name">{p.profile_name}</div>
-                            <div className="lm-profile-item-meta">
-                              {p.block_weights?.length ?? 0} blocks &middot; {p.updated_at}
-                            </div>
+                          <div className="lm-profile-item-info" title={p.profile_name}>
+                            <span className="lm-profile-item-name">{p.profile_name}</span>
+                            <span className="lm-profile-item-meta">
+                              ({p.block_weights?.length ?? 0} blocks, {formatDateOnly(p.updated_at)})
+                            </span>
                           </div>
                           <div className="lm-profile-item-actions">
                             <button className="lm-action-btn lm-action-btn-sm" onClick={() => handleLoadProfile(p)} title="Load this profile into view">


### PR DESCRIPTION
### Motivation
- Implement Phase 5.1 Steps 3–8 to let users edit block weights inline, preserve edits until explicit save, and simplify the LoRA details / profiles UI while keeping defensive behavior and minimal layout changes.
- Ensure edits never mutate original/extracted weights in-place and require explicit POST/PUT to save profiles.

### Description
- Added inline block-weight editing with numeric validation and clamping (`0.0`–`2.0`) and a local dirty flag using `clampWeight`, `formatWeightValue`, and editing state variables; edited values are local until saved. (`Database/UI/src/App.jsx`, `Database/UI/src/App.css`)
- Implemented unsaved-change guard `runWithUnsavedGuard` that intercepts navigation/filter/pagination/sort/search actions and implements the required flows: when no profile is loaded offer save-as-new vs discard, and when a profile is loaded offer update-existing vs save-as-new vs discard-to-loaded; saves use `POST /api/lora/{stable_id}/profiles` and updates use `PUT /api/lora/{stable_id}/profiles/{profile_id}`. (`Database/UI/src/App.jsx`)
- Updated Copy Weights formatting to produce comma-separated values clamped to `0..2`, rounded to at most 3 decimals then trimmed of trailing zeros (e.g. `0`, `0.2`, `1.5`, `1.333`) via `formatWeightValue`. (`Database/UI/src/App.jsx`)
- Simplified LoRA details panel by removing redundant metadata fields and removing copy buttons for ID/Name/Path, and standardized timestamps display to `YYYY-MM-DD` using `formatDateOnly`. (`Database/UI/src/App.jsx`, `Database/UI/src/App.css`)
- Compact single-line saved-profile rows with ellipsis truncation and right-aligned `Load`/`Edit`/`Del` actions, plus subtle visual feedback when a profile is loaded (header shows `BLOCK WEIGHTS (PROFILE: "...")`, block rows get a subtle style) and a `Revert to Original` action that restores extracted weights. (`Database/UI/src/App.jsx`, `Database/UI/src/App.css`)

### Testing
- Ran linting with `npm run lint` in `Database/UI` and it completed successfully after fixes.
- Built the frontend with `npm run build` (Vite) and the production build completed successfully.
- Started the dev server with `npm run dev` and confirmed it served the UI; a Playwright script captured a screenshot of the updated UI to validate visual changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699334ecb2c883218610b1fd9edb8079)