### PR TITLE
Standardize /api/lora/combine fallback exclusion and structured reason objects

### DIFF
--- a/Database/backend/lora_composer.py
+++ b/Database/backend/lora_composer.py
@@ -40,9 +40,15 @@ def layout_supports_ab(block_layout: Optional[str]) -> bool:
 
 
 def validate_compatibility(loras: List[LoRAComposeInput]) -> Dict[str, Any]:
-    reasons: List[str] = []
+    reasons: List[Dict[str, Any]] = []
     if not loras:
-        reasons.append("No LoRAs available for validation.")
+        reasons.append(
+            {
+                "code": "no_loras",
+                "detail": "No LoRAs available for validation.",
+                "stable_ids": [],
+            }
+        )
         return {
             "compatible": False,
             "reasons": reasons,
@@ -52,11 +58,24 @@ def validate_compatibility(loras: List[LoRAComposeInput]) -> Dict[str, Any]:
 
     base_models = {(l.base_model_code or "").upper() for l in loras}
     layouts = {(l.block_layout or "").lower() for l in loras}
+    stable_ids = [l.stable_id for l in loras]
 
     if len(base_models) != 1:
-        reasons.append("Selected LoRAs have mismatched base_model_code values.")
+        reasons.append(
+            {
+                "code": "base_model_mismatch",
+                "detail": "Selected LoRAs have mismatched base_model_code values.",
+                "stable_ids": stable_ids,
+            }
+        )
     if len(layouts) != 1:
-        reasons.append("Selected LoRAs have mismatched block_layout values.")
+        reasons.append(
+            {
+                "code": "layout_mismatch",
+                "detail": "Selected LoRAs have mismatched block_layout values.",
+                "stable_ids": stable_ids,
+            }
+        )
 
     compatible = len(reasons) == 0
     if compatible:

--- a/Database/backend/tests/test_lora_combine_api.py
+++ b/Database/backend/tests/test_lora_combine_api.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+import sqlite3
+import sys
+
+from fastapi.testclient import TestClient
+import pytest
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault("delta_inspector_engine", types.SimpleNamespace(inspect_lora=lambda *args, **kwargs: None))
+import lora_api_server  # noqa: E402
+
+
+def _init_test_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            stable_id TEXT UNIQUE,
+            filename TEXT,
+            base_model_code TEXT,
+            block_layout TEXT,
+            has_block_weights INTEGER
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE lora_block_weights (
+            stable_id TEXT,
+            block_index INTEGER,
+            weight REAL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_lora(
+    conn: sqlite3.Connection,
+    *,
+    stable_id: str,
+    filename: str,
+    base_model_code: str,
+    block_layout: str,
+    has_block_weights: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO lora (stable_id, filename, base_model_code, block_layout, has_block_weights)
+        VALUES (?, ?, ?, ?, ?);
+        """,
+        (stable_id, filename, base_model_code, block_layout, has_block_weights),
+    )
+
+
+def _insert_weights(conn: sqlite3.Connection, stable_id: str, weights: list[float]) -> None:
+    conn.executemany(
+        """
+        INSERT INTO lora_block_weights (stable_id, block_index, weight)
+        VALUES (?, ?, ?);
+        """,
+        [(stable_id, idx, weight) for idx, weight in enumerate(weights)],
+    )
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "combine_test.sqlite"
+    _init_test_db(db_path)
+    monkeypatch.setattr(lora_api_server, "DB_PATH", db_path)
+    monkeypatch.setattr(lora_api_server, "_schema_migrations_done", False)
+    with TestClient(lora_api_server.app) as client:
+        yield client, db_path
+
+
+def test_combine_only_fallback_loras_returns_400_with_policy_reason(client_with_temp_db):
+    client, db_path = client_with_temp_db
+    conn = sqlite3.connect(db_path)
+    _insert_lora(
+        conn,
+        stable_id="FLX-FALL-001",
+        filename="fallback_one.safetensors",
+        base_model_code="FLX",
+        block_layout="flux_transformer_3",
+        has_block_weights=0,
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post("/api/lora/combine", json={"stable_ids": ["FLX-FALL-001"], "per_lora": {}})
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["included_loras"] == []
+    assert detail["excluded_loras"][0]["reason_code"] == "fallback_excluded"
+    assert detail["reasons"][0]["code"] == "all_loras_excluded"
+    assert any("fallback LoRAs are not allowed in /api/lora/combine" in warning for warning in detail["warnings"])
+
+
+def test_combine_mixed_real_and_fallback_returns_200_and_excludes_fallback(client_with_temp_db):
+    client, db_path = client_with_temp_db
+    conn = sqlite3.connect(db_path)
+    _insert_lora(
+        conn,
+        stable_id="FLX-REAL-001",
+        filename="real.safetensors",
+        base_model_code="FLX",
+        block_layout="flux_transformer_3",
+        has_block_weights=1,
+    )
+    _insert_weights(conn, "FLX-REAL-001", [0.2, 0.4, 0.6])
+    _insert_lora(
+        conn,
+        stable_id="FLX-FALL-001",
+        filename="fallback_one.safetensors",
+        base_model_code="FLX",
+        block_layout="flux_transformer_3",
+        has_block_weights=0,
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        "/api/lora/combine",
+        json={"stable_ids": ["FLX-REAL-001", "FLX-FALL-001"], "per_lora": {}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["included_loras"] == ["FLX-REAL-001"]
+    assert body["excluded_loras"][0]["reason_code"] == "fallback_excluded"
+    assert any("Excluded 1 fallback LoRA(s)" in warning for warning in body["warnings"])
+
+
+def test_combine_base_model_mismatch_uses_structured_reason_objects(client_with_temp_db):
+    client, db_path = client_with_temp_db
+    conn = sqlite3.connect(db_path)
+    _insert_lora(
+        conn,
+        stable_id="FLX-REAL-001",
+        filename="real_a.safetensors",
+        base_model_code="FLX",
+        block_layout="flux_transformer_3",
+        has_block_weights=1,
+    )
+    _insert_weights(conn, "FLX-REAL-001", [0.2, 0.4, 0.6])
+    _insert_lora(
+        conn,
+        stable_id="SDX-REAL-002",
+        filename="real_b.safetensors",
+        base_model_code="SDX",
+        block_layout="flux_transformer_3",
+        has_block_weights=1,
+    )
+    _insert_weights(conn, "SDX-REAL-002", [0.6, 0.8, 1.0])
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        "/api/lora/combine",
+        json={"stable_ids": ["FLX-REAL-001", "SDX-REAL-002"], "per_lora": {}},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["compatible"] is False
+    assert any(reason["code"] == "base_model_mismatch" for reason in detail["reasons"])
+    mismatch_reason = next(reason for reason in detail["reasons"] if reason["code"] == "base_model_mismatch")
+    assert mismatch_reason["stable_ids"] == ["FLX-REAL-001", "SDX-REAL-002"]

--- a/Database/backend/tests/test_lora_composer.py
+++ b/Database/backend/tests/test_lora_composer.py
@@ -66,7 +66,8 @@ def test_combine_rejects_layout_mismatch():
     validation = validate_compatibility(loras)
 
     assert validation["compatible"] is False
-    assert any("mismatched block_layout" in reason for reason in validation["reasons"])
+    assert any(reason["code"] == "layout_mismatch" for reason in validation["reasons"])
+    assert validation["reasons"][0]["stable_ids"] == ["FLX-AAA-001", "FLX-BBB-002"]
 
 
 def test_combine_rejects_base_model_mismatch():
@@ -77,7 +78,8 @@ def test_combine_rejects_base_model_mismatch():
     validation = validate_compatibility(loras)
 
     assert validation["compatible"] is False
-    assert any("mismatched base_model_code" in reason for reason in validation["reasons"])
+    assert any(reason["code"] == "base_model_mismatch" for reason in validation["reasons"])
+    assert validation["reasons"][0]["stable_ids"] == ["FLX-AAA-001", "SDX-BBB-002"]
 
 
 def test_combine_zero_strength_model_returns_zeros_and_warning():


### PR DESCRIPTION
### Motivation
- Enforce an explicit policy that LoRAs with no scanned block weights (fallback LoRAs) are always excluded from `POST /api/lora/combine` with no inference or neutral weights.  
- Make exclusion and compatibility responses machine-readable and consistent so callers and automated systems can rely on stable reason codes.  
- Keep changes backend-only, deterministic, and minimal in scope to preserve existing compose math and endpoints.

### Description
- Added explicit constants and helpers: `FALLBACK_EXCLUDED_REASON_CODE` / `FALLBACK_EXCLUDED_REASON_DETAIL` and `_make_excluded_lora_entry` to produce structured excluded entries including optional `filename`.  
- Changed the combine flow to return `excluded_loras` as structured objects (with `stable_id`, `filename` when available, `reason_code`, and `reason_detail`) and to always record fallback exclusions (LoRAs with no rows in `lora_block_weights`) using `reason_code: "fallback_excluded"`.  
- When all requested LoRAs are excluded, the endpoint now returns HTTP 400 with a structured payload that includes `included_loras: []`, structured `excluded_loras`, `reasons` containing a `code: "all_loras_excluded"` object, and a clear policy `warnings` message.  
- Standardized compatibility validation by changing `validate_compatibility` to return structured reason objects with `code` (e.g. `base_model_mismatch`, `layout_mismatch`), `detail`, and `stable_ids` instead of plain strings.  
- Tests: updated `Database/backend/tests/test_lora_composer.py` assertions to expect structured reasons and added `Database/backend/tests/test_lora_combine_api.py`, a focused FastAPI `TestClient` test suite that uses a temporary sqlite DB (no writes to the real DB) to verify fallback exclusion, mixed inclusion, and structured mismatch reasons.

### Testing
- Ran the composer unit tests and the new combine API tests with `pytest -q Database/backend/tests/test_lora_composer.py Database/backend/tests/test_lora_combine_api.py`, and all tests passed (`10 passed`).  
- The API tests use a temporary sqlite DB created during the tests and monkeypatch `DB_PATH` so there are no writes to the real `lora_master.db`.  
- No frontend changes were made and combine math behavior is unchanged as verified by existing composer tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c70a1cf483219e2aba19adc97621)