### PR TITLE
Phase 8.1: derive read-only LoRA role from folder path

### DIFF
--- a/Database/UI/src/App.css
+++ b/Database/UI/src/App.css
@@ -1481,3 +1481,14 @@ button.lm-main-pill:disabled {
   background: rgba(55, 65, 81, 0.9);
   border-radius: 999px;
 }
+
+.lm-role-pill {
+  background: #1e1e2a;
+  border: 1px solid #3a3a4f;
+  padding: 2px 6px;
+  font-size: 10px;
+  border-radius: 4px;
+  margin-left: 6px;
+  letter-spacing: 0.5px;
+  color: #9aa0ff;
+}

--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -435,6 +435,9 @@ function CombineSelectedCard({ item, computed, recommendedModel, recommendedClip
           <span className="lm-combine-chip lm-combine-chip-id" title={sid}>
             {sid}
           </span>
+          <span className="lm-role-pill">
+            {(item?.role || "other").toUpperCase()}
+          </span>
           <span className="lm-combine-chip lm-combine-chip-state" title={rawFilename} style={{ minWidth: 0 }}>
             <span className="lm-combine-chip-file">{displayName}</span>
           </span>


### PR DESCRIPTION
### Motivation
- Provide a deterministic, read-only `role` derived from each LoRA `file_path` so UI and API can surface folder-derived role metadata without changing combine/stacking/block/clip logic or DB schema.

### Description
- Added `derive_role_from_path(file_path)` in `Database/backend/lora_api_server.py` with the requested folder→role mapping and `other` fallback, and made it robust to Windows-style paths.
- Exposed `role` in list responses by adding an `/api/lora/catalog` alias to `api_lora_search` and injecting `role` into each search result row, deriving it from `file_path` (safe when `file_path` is missing via `PRAGMA table_info`).
- Included `role` in `/api/lora/combine` payloads by adding `role` to `node_payloads` and to excluded/fallback entries (updated `_make_excluded_lora_entry` to accept an optional `role`), while keeping all combine math and existing fields untouched.
- UI: added a read-only uppercase role pill to Combine Selected Stack cards and minimal CSS in `Database/UI/src/App.css` to style `.lm-role-pill` without altering layout or scroll rules.
- Files changed: `Database/backend/lora_api_server.py`, `Database/UI/src/App.jsx`, `Database/UI/src/App.css`.

### Testing
- Ran unit tests with `python -m pytest -q` and all tests passed (`14 passed, 1 skipped`).
- Built the frontend with `cd Database/UI && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998424a28588321af9af79c8da78c4b)