### PR TITLE
Phase 8.5: add block orchestrator skeleton

### DIFF
--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from lora_composer import weights_to_csv
+
+
+@dataclass(frozen=True)
+class LoraBlockOrchestratorInput:
+    stable_id: str
+    filename: Optional[str]
+    role: str
+    base_model_code: Optional[str]
+    block_layout: Optional[str]
+    text_encoder_contributor: bool
+    affect_text_encoder: bool
+    strength_model: float
+    strength_text_encoder: float
+    block_weights: List[float]
+
+
+@dataclass(frozen=True)
+class LoraBlockOrchestratorOutput:
+    stable_id: str
+    filename: Optional[str]
+    role: str
+    base_model_code: Optional[str]
+    block_layout: Optional[str]
+    text_encoder_contributor: bool
+    affect_text_encoder: bool
+    strength_model: float
+    strength_text_encoder: Optional[float]
+    block_weights: List[float]
+    block_weights_csv: str
+    notes: List[str]
+
+
+def orchestrate_lora_block_payloads(
+    inputs: List[LoraBlockOrchestratorInput],
+) -> List[LoraBlockOrchestratorOutput]:
+    """Return one stack-aware payload per selected LoRA.
+
+    This is the Phase 8.5 skeleton only. It deliberately preserves current
+    per-LoRA block vectors so adding the module does not change runtime behaviour.
+    Future amendments will add role-aware, block-level adjustment here.
+    """
+    outputs: List[LoraBlockOrchestratorOutput] = []
+
+    for entry in inputs:
+        block_weights = [float(value) for value in entry.block_weights]
+        affect_text_encoder = bool(entry.affect_text_encoder and entry.text_encoder_contributor)
+        strength_text_encoder: Optional[float]
+        if affect_text_encoder:
+            strength_text_encoder = float(entry.strength_text_encoder)
+        else:
+            strength_text_encoder = 0.0
+
+        outputs.append(
+            LoraBlockOrchestratorOutput(
+                stable_id=entry.stable_id,
+                filename=entry.filename,
+                role=entry.role,
+                base_model_code=entry.base_model_code,
+                block_layout=entry.block_layout,
+                text_encoder_contributor=bool(entry.text_encoder_contributor),
+                affect_text_encoder=affect_text_encoder,
+                strength_model=float(entry.strength_model),
+                strength_text_encoder=strength_text_encoder,
+                block_weights=block_weights,
+                block_weights_csv=weights_to_csv(block_weights),
+                notes=[
+                    "Phase 8.5 skeleton: scanned per-LoRA block weights are preserved; "
+                    "stack-aware block-vector adjustment is not implemented yet."
+                ],
+            )
+        )
+
+    return outputs

--- a/Database/backend/tests/test_lora_block_orchestrator.py
+++ b/Database/backend/tests/test_lora_block_orchestrator.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from lora_block_orchestrator import (  # noqa: E402
+    LoraBlockOrchestratorInput,
+    orchestrate_lora_block_payloads,
+)
+
+
+def _input(
+    stable_id: str,
+    *,
+    role: str = "character",
+    text_encoder_contributor: bool = False,
+    affect_text_encoder: bool = True,
+    strength_text_encoder: float = 0.0,
+    weights: list[float] | None = None,
+) -> LoraBlockOrchestratorInput:
+    return LoraBlockOrchestratorInput(
+        stable_id=stable_id,
+        filename=f"{stable_id}.safetensors",
+        role=role,
+        base_model_code="FLX",
+        block_layout="flux_transformer_3",
+        text_encoder_contributor=text_encoder_contributor,
+        affect_text_encoder=affect_text_encoder,
+        strength_model=1.25,
+        strength_text_encoder=strength_text_encoder,
+        block_weights=weights or [0.2, 0.4, 0.6],
+    )
+
+
+def test_orchestrator_returns_one_payload_per_lora_in_order() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001"),
+        _input("FLX-BBB-002", role="style"),
+    ])
+
+    assert [output.stable_id for output in outputs] == ["FLX-AAA-001", "FLX-BBB-002"]
+    assert [output.role for output in outputs] == ["character", "style"]
+
+
+def test_orchestrator_preserves_scanned_block_vectors_for_skeleton() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001", weights=[0.12345, 0.5, 1.0]),
+    ])
+
+    assert outputs[0].block_weights == [0.12345, 0.5, 1.0]
+    assert outputs[0].block_weights_csv == "0.1235,0.5000,1.0000"
+    assert outputs[0].notes
+
+
+def test_orchestrator_disables_text_encoder_when_no_text_encoder_tensors() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input(
+            "FLX-AAA-001",
+            text_encoder_contributor=False,
+            affect_text_encoder=True,
+            strength_text_encoder=2.0,
+        ),
+    ])
+
+    assert outputs[0].text_encoder_contributor is False
+    assert outputs[0].affect_text_encoder is False
+    assert outputs[0].strength_text_encoder == 0.0
+
+
+def test_orchestrator_preserves_text_encoder_strength_when_allowed() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input(
+            "FLX-AAA-001",
+            text_encoder_contributor=True,
+            affect_text_encoder=True,
+            strength_text_encoder=0.75,
+        ),
+    ])
+
+    assert outputs[0].text_encoder_contributor is True
+    assert outputs[0].affect_text_encoder is True
+    assert outputs[0].strength_text_encoder == 0.75


### PR DESCRIPTION
## Summary

Adds the first `lora_block_orchestrator.py` skeleton for Phase 8.5 without changing runtime combine behaviour yet.

## Changes

- Adds `Database/backend/lora_block_orchestrator.py` as the future home for stack-aware, role-aware, per-LoRA block orchestration.
- Defines explicit input/output dataclasses for per-LoRA orchestration payloads.
- Adds `orchestrate_lora_block_payloads(...)`, which currently returns one output per input and preserves scanned block vectors unchanged.
- Adds `Database/backend/tests/test_lora_block_orchestrator.py` to lock the skeleton contract.

## Testing

Run locally on Bender:

```text
pytest -q tests/test_lora_block_orchestrator.py tests/test_phase85_contract.py tests/test_lora_energy_overlap.py
```

Result:

```text
9 passed, 1 xfailed
```

## Scope note

This PR intentionally does not integrate the orchestrator into `/api/lora/combine` yet. It creates the module seam first so the next amendments can move combine payload construction into the orchestrator in small, testable steps.