### PR TITLE
Phase 8.5: soften overlapping same-role block vectors

### DIFF
--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from lora_composer import weights_to_csv
+from lora_energy_overlap import (
+    LoRAEnergyInput,
+    OVERLAP_THRESHOLD,
+    canonicalize_role,
+    compute_lora_energy_metrics,
+    dot_overlap,
+)
 
 
 @dataclass(frozen=True)
@@ -36,25 +43,150 @@ class LoraBlockOrchestratorOutput:
     notes: List[str]
 
 
+def _same_adjustable_block_space(
+    left: LoraBlockOrchestratorInput,
+    right: LoraBlockOrchestratorInput,
+) -> Tuple[bool, str]:
+    left_role = canonicalize_role(left.role)
+    right_role = canonicalize_role(right.role)
+    if left_role != right_role:
+        return False, left_role
+
+    # `other` is intentionally excluded in the first behaviour pass. Unknown role
+    # taxonomy is not strong enough evidence for block-vector collision handling.
+    if left_role == "other":
+        return False, left_role
+
+    if (left.block_layout or "").lower() != (right.block_layout or "").lower():
+        return False, left_role
+
+    if len(left.block_weights) != len(right.block_weights):
+        return False, left_role
+
+    return True, left_role
+
+
+def _overlap_for_vectors(
+    left: LoraBlockOrchestratorInput,
+    right: LoraBlockOrchestratorInput,
+    left_weights: List[float],
+    right_weights: List[float],
+) -> float:
+    left_metrics = compute_lora_energy_metrics(
+        LoRAEnergyInput(
+            stable_id=left.stable_id,
+            role=left.role,
+            block_weights=left_weights,
+            raw_strength_factor=left.strength_model,
+        )
+    )
+    right_metrics = compute_lora_energy_metrics(
+        LoRAEnergyInput(
+            stable_id=right.stable_id,
+            role=right.role,
+            block_weights=right_weights,
+            raw_strength_factor=right.strength_model,
+        )
+    )
+    return dot_overlap(
+        left_metrics.normalized_energy_vector,
+        right_metrics.normalized_energy_vector,
+    )
+
+
+def _soften_same_role_overlaps(
+    inputs: List[LoraBlockOrchestratorInput],
+    adjusted_weights: Dict[str, List[float]],
+    notes_by_id: Dict[str, List[str]],
+    *,
+    overlap_threshold: float = OVERLAP_THRESHOLD,
+) -> None:
+    by_id = {entry.stable_id: entry for entry in inputs}
+    ordered_ids = sorted(by_id)
+
+    for left_pos, left_id in enumerate(ordered_ids):
+        left = by_id[left_id]
+        for right_id in ordered_ids[left_pos + 1:]:
+            right = by_id[right_id]
+            should_adjust, role = _same_adjustable_block_space(left, right)
+            if not should_adjust:
+                continue
+
+            left_weights = adjusted_weights[left.stable_id]
+            right_weights = adjusted_weights[right.stable_id]
+            overlap = _overlap_for_vectors(left, right, left_weights, right_weights)
+            if overlap <= overlap_threshold or overlap <= 0.0:
+                continue
+
+            scale_factor = overlap_threshold / overlap
+            left_changed = False
+            right_changed = False
+
+            for idx, (left_value, right_value) in enumerate(zip(left_weights, right_weights)):
+                if abs(left_value) <= 0.0 or abs(right_value) <= 0.0:
+                    continue
+
+                left_abs = abs(left_value)
+                right_abs = abs(right_value)
+                if left_abs > right_abs:
+                    right_weights[idx] = right_value * scale_factor
+                    right_changed = True
+                elif right_abs > left_abs:
+                    left_weights[idx] = left_value * scale_factor
+                    left_changed = True
+                else:
+                    # Deterministic tie-break: stable_id lexical order keeps the
+                    # first item intact and softens the later one.
+                    right_weights[idx] = right_value * scale_factor
+                    right_changed = True
+
+            detail = (
+                f"Same-role ({role}) block overlap softening applied against "
+                f"{{peer}}: overlap={overlap:.4f}, scale={scale_factor:.4f}."
+            )
+            if left_changed:
+                notes_by_id[left.stable_id].append(detail.format(peer=right.stable_id))
+            if right_changed:
+                notes_by_id[right.stable_id].append(detail.format(peer=left.stable_id))
+
+
 def orchestrate_lora_block_payloads(
     inputs: List[LoraBlockOrchestratorInput],
 ) -> List[LoraBlockOrchestratorOutput]:
     """Return one stack-aware payload per selected LoRA.
 
-    This is the Phase 8.5 skeleton only. It deliberately preserves current
-    per-LoRA block vectors so adding the module does not change runtime behaviour.
-    Future amendments will add role-aware, block-level adjustment here.
+    This is the first behavioural Phase 8.5 pass. It keeps one output per LoRA
+    and applies deterministic same-role, same-layout block-vector softening when
+    measured overlap exceeds the fixed overlap threshold. The legacy averaged
+    `combined` payload remains outside this module.
     """
-    outputs: List[LoraBlockOrchestratorOutput] = []
+    adjusted_weights: Dict[str, List[float]] = {
+        entry.stable_id: [float(value) for value in entry.block_weights]
+        for entry in inputs
+    }
+    notes_by_id: Dict[str, List[str]] = {
+        entry.stable_id: []
+        for entry in inputs
+    }
 
+    _soften_same_role_overlaps(inputs, adjusted_weights, notes_by_id)
+
+    outputs: List[LoraBlockOrchestratorOutput] = []
     for entry in inputs:
-        block_weights = [float(value) for value in entry.block_weights]
+        block_weights = adjusted_weights[entry.stable_id]
         affect_text_encoder = bool(entry.affect_text_encoder and entry.text_encoder_contributor)
         strength_text_encoder: Optional[float]
         if affect_text_encoder:
             strength_text_encoder = float(entry.strength_text_encoder)
         else:
             strength_text_encoder = 0.0
+
+        notes = list(notes_by_id[entry.stable_id])
+        if not notes:
+            notes.append(
+                "Phase 8.5: no same-role block-vector softening was applied; "
+                "per-LoRA block weights are preserved."
+            )
 
         outputs.append(
             LoraBlockOrchestratorOutput(
@@ -69,10 +201,7 @@ def orchestrate_lora_block_payloads(
                 strength_text_encoder=strength_text_encoder,
                 block_weights=block_weights,
                 block_weights_csv=weights_to_csv(block_weights),
-                notes=[
-                    "Phase 8.5 skeleton: scanned per-LoRA block weights are preserved; "
-                    "stack-aware block-vector adjustment is not implemented yet."
-                ],
+                notes=notes,
             )
         )
 

--- a/Database/backend/tests/test_lora_block_orchestrator.py
+++ b/Database/backend/tests/test_lora_block_orchestrator.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from lora_block_orchestrator import (  # noqa: E402
@@ -13,8 +15,10 @@ def _input(
     stable_id: str,
     *,
     role: str = "character",
+    block_layout: str = "flux_transformer_3",
     text_encoder_contributor: bool = False,
     affect_text_encoder: bool = True,
+    strength_model: float = 1.25,
     strength_text_encoder: float = 0.0,
     weights: list[float] | None = None,
 ) -> LoraBlockOrchestratorInput:
@@ -23,10 +27,10 @@ def _input(
         filename=f"{stable_id}.safetensors",
         role=role,
         base_model_code="FLX",
-        block_layout="flux_transformer_3",
+        block_layout=block_layout,
         text_encoder_contributor=text_encoder_contributor,
         affect_text_encoder=affect_text_encoder,
-        strength_model=1.25,
+        strength_model=strength_model,
         strength_text_encoder=strength_text_encoder,
         block_weights=weights or [0.2, 0.4, 0.6],
     )
@@ -42,7 +46,7 @@ def test_orchestrator_returns_one_payload_per_lora_in_order() -> None:
     assert [output.role for output in outputs] == ["character", "style"]
 
 
-def test_orchestrator_preserves_scanned_block_vectors_for_skeleton() -> None:
+def test_orchestrator_preserves_scanned_block_vectors_when_no_softening_applies() -> None:
     outputs = orchestrate_lora_block_payloads([
         _input("FLX-AAA-001", weights=[0.12345, 0.5, 1.0]),
     ])
@@ -50,6 +54,57 @@ def test_orchestrator_preserves_scanned_block_vectors_for_skeleton() -> None:
     assert outputs[0].block_weights == [0.12345, 0.5, 1.0]
     assert outputs[0].block_weights_csv == "0.1235,0.5000,1.0000"
     assert outputs[0].notes
+
+
+def test_orchestrator_softens_overlapping_same_role_block_vectors() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001", role="character", weights=[1.0, 1.0, 0.2]),
+        _input("FLX-BBB-002", role="character", weights=[1.0, 0.9, 0.1]),
+    ])
+
+    by_id = {output.stable_id: output for output in outputs}
+
+    # Stable-id ordering keeps FLX-AAA-001 intact on exact ties and softens the
+    # later/overlapping peer. This is deterministic, not divide-by-N scaling.
+    assert by_id["FLX-AAA-001"].block_weights == [1.0, 1.0, 0.2]
+    assert by_id["FLX-BBB-002"].block_weights != [1.0, 0.9, 0.1]
+    assert by_id["FLX-BBB-002"].block_weights[0] < 1.0
+    assert by_id["FLX-BBB-002"].block_weights[1] < 0.9
+    assert by_id["FLX-BBB-002"].block_weights[2] < 0.1
+    assert any("Same-role" in note for note in by_id["FLX-BBB-002"].notes)
+
+
+def test_orchestrator_does_not_soften_different_roles() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001", role="character", weights=[1.0, 1.0, 0.2]),
+        _input("FLX-BBB-002", role="style", weights=[1.0, 0.9, 0.1]),
+    ])
+
+    by_id = {output.stable_id: output for output in outputs}
+    assert by_id["FLX-AAA-001"].block_weights == [1.0, 1.0, 0.2]
+    assert by_id["FLX-BBB-002"].block_weights == [1.0, 0.9, 0.1]
+
+
+def test_orchestrator_does_not_soften_different_layouts() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001", role="character", block_layout="flux_transformer_3", weights=[1.0, 1.0, 0.2]),
+        _input("FLX-BBB-002", role="character", block_layout="flux_double_3", weights=[1.0, 0.9, 0.1]),
+    ])
+
+    by_id = {output.stable_id: output for output in outputs}
+    assert by_id["FLX-AAA-001"].block_weights == [1.0, 1.0, 0.2]
+    assert by_id["FLX-BBB-002"].block_weights == [1.0, 0.9, 0.1]
+
+
+def test_orchestrator_csv_matches_softened_block_vector() -> None:
+    outputs = orchestrate_lora_block_payloads([
+        _input("FLX-AAA-001", role="character", weights=[1.0, 1.0, 0.2]),
+        _input("FLX-BBB-002", role="character", weights=[1.0, 0.9, 0.1]),
+    ])
+
+    softened = next(output for output in outputs if output.stable_id == "FLX-BBB-002")
+    csv_values = [float(value) for value in softened.block_weights_csv.split(",")]
+    assert csv_values == pytest.approx([round(value, 4) for value in softened.block_weights])
 
 
 def test_orchestrator_disables_text_encoder_when_no_text_encoder_tensors() -> None:


### PR DESCRIPTION
## Summary

Implements the first behavioural Phase 8.5 block-vector orchestration pass.

The orchestrator now applies deterministic same-role, same-layout block-vector softening when measured L2/cosine overlap exceeds the fixed overlap threshold.

## Changes

- Updates `lora_block_orchestrator.py` to detect same-role, same-layout overlaps using true L2/cosine overlap.
- Applies per-block softening to the lower/equal-priority overlapping peer instead of only changing global strength.
- Keeps behaviour deterministic with stable-id ordering for exact ties.
- Excludes role `other` from this first behavioural pass.
- Keeps the legacy `combined` payload untouched.
- Adds tests for:
  - same-role overlap softening
  - no softening across different roles
  - no softening across different layouts
  - CSV matching softened vectors
  - existing text-encoder handling

## Testing

Run locally on Bender:

```text
pytest -q tests/test_lora_block_orchestrator.py tests/test_phase85_contract.py tests/test_lora_energy_overlap.py tests/test_lora_combine_api.py
```

Result:

```text
21 passed, 1 xfailed
```

## Scope note

This is the first small behavioural orchestration pass. It does not remove the legacy combined payload and does not change compatibility rules. It only changes per-LoRA node payload block vectors when same-role/same-layout overlap is high enough to justify deterministic softening.