### PR TITLE
Phase 8.5: recheck same-role overlap groups

### DIFF
--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -12,6 +12,9 @@ from lora_energy_overlap import (
     dot_overlap,
 )
 
+MAX_SOFTENING_PASSES = 20
+OVERLAP_EPSILON = 1e-6
+
 
 @dataclass(frozen=True)
 class LoraBlockOrchestratorInput:
@@ -43,6 +46,10 @@ class LoraBlockOrchestratorOutput:
     notes: List[str]
 
 
+AdjustableGroupKey = Tuple[str, str, int]
+WorstPair = Tuple[float, LoraBlockOrchestratorInput, LoraBlockOrchestratorInput]
+
+
 def _same_adjustable_block_space(
     left: LoraBlockOrchestratorInput,
     right: LoraBlockOrchestratorInput,
@@ -64,6 +71,13 @@ def _same_adjustable_block_space(
         return False, left_role
 
     return True, left_role
+
+
+def _adjustable_group_key(entry: LoraBlockOrchestratorInput) -> Optional[AdjustableGroupKey]:
+    role = canonicalize_role(entry.role)
+    if role == "other":
+        return None
+    return (role, (entry.block_layout or "").lower(), len(entry.block_weights))
 
 
 def _overlap_for_vectors(
@@ -188,39 +202,150 @@ def _reduce_pair_overlap(
     return target.stable_id, changed_indices, initial_overlap, current_overlap
 
 
+def _find_worst_violating_pair(
+    group: List[LoraBlockOrchestratorInput],
+    adjusted_weights: Dict[str, List[float]],
+    *,
+    overlap_threshold: float,
+) -> Optional[WorstPair]:
+    worst: Optional[WorstPair] = None
+
+    for left_pos, left in enumerate(group):
+        for right in group[left_pos + 1:]:
+            overlap = _overlap_for_vectors(
+                left,
+                right,
+                adjusted_weights[left.stable_id],
+                adjusted_weights[right.stable_id],
+            )
+            if overlap <= overlap_threshold + OVERLAP_EPSILON:
+                continue
+
+            if worst is None:
+                worst = (overlap, left, right)
+                continue
+
+            worst_overlap, worst_left, worst_right = worst
+            candidate_pair = (left.stable_id, right.stable_id)
+            worst_pair = (worst_left.stable_id, worst_right.stable_id)
+            if overlap > worst_overlap + OVERLAP_EPSILON or (
+                abs(overlap - worst_overlap) <= OVERLAP_EPSILON
+                and candidate_pair < worst_pair
+            ):
+                worst = (overlap, left, right)
+
+    return worst
+
+
+def _format_softening_note(
+    *,
+    role: str,
+    peer_id: str,
+    initial_overlap: float,
+    final_overlap: float,
+    overlap_threshold: float,
+    changed_indices: List[int],
+    pass_index: int,
+) -> str:
+    if final_overlap <= overlap_threshold + OVERLAP_EPSILON:
+        outcome = "reached threshold for this pass"
+    else:
+        outcome = "reduced overlap; threshold not reached"
+
+    return (
+        f"Same-role ({role}) block overlap softening {outcome} against {peer_id}: "
+        f"overlap={initial_overlap:.4f}->{final_overlap:.4f}, "
+        f"threshold={overlap_threshold:.4f}, "
+        f"adjusted_blocks={changed_indices}, pass={pass_index}."
+    )
+
+
 def _soften_same_role_overlaps(
     inputs: List[LoraBlockOrchestratorInput],
     adjusted_weights: Dict[str, List[float]],
     notes_by_id: Dict[str, List[str]],
     *,
     overlap_threshold: float = OVERLAP_THRESHOLD,
+    max_passes: int = MAX_SOFTENING_PASSES,
 ) -> None:
-    by_id = {entry.stable_id: entry for entry in inputs}
-    ordered_ids = sorted(by_id)
+    groups: Dict[AdjustableGroupKey, List[LoraBlockOrchestratorInput]] = {}
+    for entry in sorted(inputs, key=lambda item: item.stable_id):
+        key = _adjustable_group_key(entry)
+        if key is None:
+            continue
+        groups.setdefault(key, []).append(entry)
 
-    for left_pos, left_id in enumerate(ordered_ids):
-        left = by_id[left_id]
-        for right_id in ordered_ids[left_pos + 1:]:
-            right = by_id[right_id]
-            should_adjust, role = _same_adjustable_block_space(left, right)
-            if not should_adjust:
-                continue
+    for (role, _layout, _block_count), group in sorted(groups.items(), key=lambda item: item[0]):
+        if len(group) < 2:
+            continue
 
+        passes_used = 0
+        for pass_index in range(1, max_passes + 1):
+            worst = _find_worst_violating_pair(
+                group,
+                adjusted_weights,
+                overlap_threshold=overlap_threshold,
+            )
+            if worst is None:
+                break
+
+            passes_used = pass_index
+            _worst_overlap, left, right = worst
             target_id, changed_indices, initial_overlap, final_overlap = _reduce_pair_overlap(
                 left=left,
                 right=right,
                 adjusted_weights=adjusted_weights,
                 overlap_threshold=overlap_threshold,
             )
+
             if target_id is None:
-                continue
+                notes_by_id[left.stable_id].append(
+                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
+                    f"pair {left.stable_id}/{right.stable_id} remains overlap={initial_overlap:.4f} "
+                    f"above threshold={overlap_threshold:.4f}; no lower-overlap block adjustment was found."
+                )
+                notes_by_id[right.stable_id].append(
+                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
+                    f"pair {left.stable_id}/{right.stable_id} remains overlap={initial_overlap:.4f} "
+                    f"above threshold={overlap_threshold:.4f}; no lower-overlap block adjustment was found."
+                )
+                break
 
             peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
             notes_by_id[target_id].append(
-                f"Same-role ({role}) block overlap softening applied against {peer_id}: "
-                f"overlap={initial_overlap:.4f}->{final_overlap:.4f}, "
-                f"adjusted_blocks={changed_indices}."
+                _format_softening_note(
+                    role=role,
+                    peer_id=peer_id,
+                    initial_overlap=initial_overlap,
+                    final_overlap=final_overlap,
+                    overlap_threshold=overlap_threshold,
+                    changed_indices=changed_indices,
+                    pass_index=pass_index,
+                )
             )
+
+            if final_overlap >= initial_overlap - OVERLAP_EPSILON:
+                notes_by_id[target_id].append(
+                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
+                    f"latest adjustment did not materially reduce overlap "
+                    f"({initial_overlap:.4f}->{final_overlap:.4f})."
+                )
+                break
+
+        remaining = _find_worst_violating_pair(
+            group,
+            adjusted_weights,
+            overlap_threshold=overlap_threshold,
+        )
+        if remaining is not None:
+            remaining_overlap, left, right = remaining
+            note = (
+                f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort "
+                f"after {passes_used} pass(es): pair {left.stable_id}/{right.stable_id} "
+                f"remains overlap={remaining_overlap:.4f} above threshold={overlap_threshold:.4f}."
+            )
+            notes_by_id[left.stable_id].append(note)
+            notes_by_id[right.stable_id].append(note)
 
 
 def orchestrate_lora_block_payloads(

--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -49,6 +49,7 @@ class LoraBlockOrchestratorOutput:
 
 AdjustableGroupKey = Tuple[str, str, int]
 GroupViolationScore = Tuple[float, int, float]
+PairAdjustmentCandidate = Tuple[str, Tuple[int, ...], float, float, List[float]]
 WorstPair = Tuple[float, LoraBlockOrchestratorInput, LoraBlockOrchestratorInput]
 
 
@@ -157,7 +158,7 @@ def _candidate_pair_overlap(
     return _overlap_for_vectors(left, right, left_weights, right_weights)
 
 
-def _build_pair_adjustment_candidate(
+def _build_pair_adjustment_candidates(
     *,
     left: LoraBlockOrchestratorInput,
     right: LoraBlockOrchestratorInput,
@@ -165,7 +166,7 @@ def _build_pair_adjustment_candidate(
     target: LoraBlockOrchestratorInput,
     block_index: int,
     overlap_threshold: float,
-) -> Optional[Tuple[str, Tuple[int, ...], float, float, List[float]]]:
+) -> List[PairAdjustmentCandidate]:
     initial_overlap = _overlap_for_vectors(
         left,
         right,
@@ -173,58 +174,98 @@ def _build_pair_adjustment_candidate(
         adjusted_weights[right.stable_id],
     )
     if initial_overlap <= overlap_threshold or initial_overlap <= 0.0:
-        return None
+        return []
 
-    target_weights = list(adjusted_weights[target.stable_id])
-    original_value = target_weights[block_index]
+    original_weights = list(adjusted_weights[target.stable_id])
+    original_value = original_weights[block_index]
     if abs(original_value) <= 0.0:
-        return None
+        return []
 
-    # First check whether removing this one block can get the pair below the
-    # threshold. If not, the zeroed value is still a candidate only when it
-    # improves the pair; group-level scoring decides whether it helps globally.
-    target_weights[block_index] = 0.0
+    candidates: List[PairAdjustmentCandidate] = []
+
+    # Always score the fully zeroed block when it improves the selected pair.
+    # A threshold-tight retained value may be locally nicer for this pair while
+    # still worsening another group member, so group-level scoring needs both
+    # options in its candidate set.
+    zero_weights = list(original_weights)
+    zero_weights[block_index] = 0.0
     zero_overlap = _candidate_pair_overlap(
         left=left,
         right=right,
         adjusted_weights=adjusted_weights,
         target_id=target.stable_id,
-        target_weights=target_weights,
+        target_weights=zero_weights,
     )
+    if zero_overlap < initial_overlap - OVERLAP_EPSILON:
+        candidates.append(
+            (
+                target.stable_id,
+                (block_index,),
+                initial_overlap,
+                zero_overlap,
+                zero_weights,
+            )
+        )
 
     if zero_overlap > overlap_threshold:
-        if zero_overlap < initial_overlap - OVERLAP_EPSILON:
-            return target.stable_id, (block_index,), initial_overlap, zero_overlap, target_weights
-        return None
+        return candidates
 
     # Binary-search the highest retained value for this block that keeps the
     # measured pair cosine overlap at or below the threshold.
+    retained_weights = list(original_weights)
     low = 0.0
     high = 1.0
     for _ in range(40):
         mid = (low + high) / 2.0
-        target_weights[block_index] = original_value * mid
+        retained_weights[block_index] = original_value * mid
         candidate_overlap = _candidate_pair_overlap(
             left=left,
             right=right,
             adjusted_weights=adjusted_weights,
             target_id=target.stable_id,
-            target_weights=target_weights,
+            target_weights=retained_weights,
         )
         if candidate_overlap <= overlap_threshold:
             low = mid
         else:
             high = mid
 
-    target_weights[block_index] = original_value * low
+    retained_weights[block_index] = original_value * low
     final_overlap = _candidate_pair_overlap(
         left=left,
         right=right,
         adjusted_weights=adjusted_weights,
         target_id=target.stable_id,
-        target_weights=target_weights,
+        target_weights=retained_weights,
     )
-    return target.stable_id, (block_index,), initial_overlap, final_overlap, target_weights
+    if final_overlap < initial_overlap - OVERLAP_EPSILON and (
+        not candidates
+        or abs(retained_weights[block_index] - zero_weights[block_index]) > OVERLAP_EPSILON
+    ):
+        candidates.append(
+            (
+                target.stable_id,
+                (block_index,),
+                initial_overlap,
+                final_overlap,
+                retained_weights,
+            )
+        )
+
+    return candidates
+
+
+def _rank_pair_candidate(
+    candidate: PairAdjustmentCandidate,
+    target: LoraBlockOrchestratorInput,
+    *,
+    overlap_threshold: float,
+) -> Tuple[int, float, float]:
+    _target_id, _changed_indices, _initial_overlap, final_overlap, target_weights = candidate
+    retained_energy = _total_energy(target, target_weights)
+    if final_overlap <= overlap_threshold + OVERLAP_EPSILON:
+        return 0, -retained_energy, final_overlap
+    return 1, final_overlap, -retained_energy
 
 
 def _reduce_pair_overlap(
@@ -252,7 +293,7 @@ def _reduce_pair_overlap(
     )
 
     for idx in contribution_by_index:
-        candidate = _build_pair_adjustment_candidate(
+        candidates = _build_pair_adjustment_candidates(
             left=left,
             right=right,
             adjusted_weights=adjusted_weights,
@@ -260,10 +301,17 @@ def _reduce_pair_overlap(
             block_index=idx,
             overlap_threshold=overlap_threshold,
         )
-        if candidate is None:
+        if not candidates:
             continue
 
-        target_id, changed_indices, _initial, final_overlap, target_weights = candidate
+        target_id, changed_indices, _initial, final_overlap, target_weights = min(
+            candidates,
+            key=lambda item: _rank_pair_candidate(
+                item,
+                target,
+                overlap_threshold=overlap_threshold,
+            ),
+        )
         adjusted_weights[target_id] = target_weights
         return target_id, list(changed_indices), initial_overlap, final_overlap
 
@@ -353,7 +401,7 @@ def _choose_best_group_adjustment(
             )
 
             for idx in contribution_by_index:
-                candidate = _build_pair_adjustment_candidate(
+                candidates = _build_pair_adjustment_candidates(
                     left=left,
                     right=right,
                     adjusted_weights=adjusted_weights,
@@ -361,43 +409,41 @@ def _choose_best_group_adjustment(
                     block_index=idx,
                     overlap_threshold=overlap_threshold,
                 )
-                if candidate is None:
-                    continue
+                for candidate in candidates:
+                    target_id, changed_indices, pair_initial, pair_final, target_weights = candidate
+                    candidate_score = _group_violation_score(
+                        group,
+                        adjusted_weights,
+                        overlap_threshold=overlap_threshold,
+                        override=(target_id, target_weights),
+                    )
+                    if not _score_not_worse(candidate_score, current_score):
+                        continue
 
-                target_id, changed_indices, pair_initial, pair_final, target_weights = candidate
-                candidate_score = _group_violation_score(
-                    group,
-                    adjusted_weights,
-                    overlap_threshold=overlap_threshold,
-                    override=(target_id, target_weights),
-                )
-                if not _score_not_worse(candidate_score, current_score):
-                    continue
+                    peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
+                    retained_energy = _total_energy(target, target_weights)
+                    ranking_score = (
+                        candidate_score[0],
+                        candidate_score[1],
+                        candidate_score[2],
+                        -retained_energy,
+                        left.stable_id,
+                        right.stable_id,
+                        target_id,
+                        changed_indices,
+                    )
 
-                peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
-                retained_energy = _total_energy(target, target_weights)
-                ranking_score = (
-                    candidate_score[0],
-                    candidate_score[1],
-                    candidate_score[2],
-                    -retained_energy,
-                    left.stable_id,
-                    right.stable_id,
-                    target_id,
-                    changed_indices,
-                )
-
-                adjustment = PairAdjustment(
-                    target_id=target_id,
-                    peer_id=peer_id,
-                    changed_indices=changed_indices,
-                    initial_overlap=pair_initial,
-                    final_overlap=pair_final,
-                    target_weights=target_weights,
-                    score=ranking_score,
-                )
-                if best is None or adjustment.score < best.score:
-                    best = adjustment
+                    adjustment = PairAdjustment(
+                        target_id=target_id,
+                        peer_id=peer_id,
+                        changed_indices=changed_indices,
+                        initial_overlap=pair_initial,
+                        final_overlap=pair_final,
+                        target_weights=target_weights,
+                        score=ranking_score,
+                    )
+                    if best is None or adjustment.score < best.score:
+                        best = adjustment
 
     return best
 

--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -61,7 +61,7 @@ class PairAdjustment:
     initial_overlap: float
     final_overlap: float
     target_weights: List[float]
-    score: Tuple[float, int, float, float, str, str, str, Tuple[int, ...]]
+    score: Tuple[float, int, float, int, float, str, str, str, Tuple[int, ...]]
 
 
 def _same_adjustable_block_space(
@@ -394,56 +394,68 @@ def _choose_best_group_adjustment(
             if initial_overlap <= overlap_threshold + OVERLAP_EPSILON:
                 continue
 
-            target = _choose_adjustment_target(left, right, left_weights, right_weights)
-            contribution_by_index = sorted(
-                range(len(adjusted_weights[target.stable_id])),
-                key=lambda idx: (-(abs(left_weights[idx]) * abs(right_weights[idx])), idx),
+            # Evaluate both peers instead of only the lower-energy target. In
+            # multi-LoRA groups, the lower-energy member can be involved in
+            # several remaining violations; editing the other side may be the
+            # only group-improving move. When group scores tie, keep the older
+            # deterministic lower-energy/stable-id preference.
+            preferred_target = _choose_adjustment_target(left, right, left_weights, right_weights)
+            targets = sorted(
+                (left, right),
+                key=lambda entry: (0 if entry.stable_id == preferred_target.stable_id else 1, entry.stable_id),
             )
-
-            for idx in contribution_by_index:
-                candidates = _build_pair_adjustment_candidates(
-                    left=left,
-                    right=right,
-                    adjusted_weights=adjusted_weights,
-                    target=target,
-                    block_index=idx,
-                    overlap_threshold=overlap_threshold,
+            for target in targets:
+                target_preference = 0 if target.stable_id == preferred_target.stable_id else 1
+                contribution_by_index = sorted(
+                    range(len(adjusted_weights[target.stable_id])),
+                    key=lambda idx: (-(abs(left_weights[idx]) * abs(right_weights[idx])), idx),
                 )
-                for candidate in candidates:
-                    target_id, changed_indices, pair_initial, pair_final, target_weights = candidate
-                    candidate_score = _group_violation_score(
-                        group,
-                        adjusted_weights,
+
+                for idx in contribution_by_index:
+                    candidates = _build_pair_adjustment_candidates(
+                        left=left,
+                        right=right,
+                        adjusted_weights=adjusted_weights,
+                        target=target,
+                        block_index=idx,
                         overlap_threshold=overlap_threshold,
-                        override=(target_id, target_weights),
                     )
-                    if not _score_not_worse(candidate_score, current_score):
-                        continue
+                    for candidate in candidates:
+                        target_id, changed_indices, pair_initial, pair_final, target_weights = candidate
+                        candidate_score = _group_violation_score(
+                            group,
+                            adjusted_weights,
+                            overlap_threshold=overlap_threshold,
+                            override=(target_id, target_weights),
+                        )
+                        if not _score_not_worse(candidate_score, current_score):
+                            continue
 
-                    peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
-                    retained_energy = _total_energy(target, target_weights)
-                    ranking_score = (
-                        candidate_score[0],
-                        candidate_score[1],
-                        candidate_score[2],
-                        -retained_energy,
-                        left.stable_id,
-                        right.stable_id,
-                        target_id,
-                        changed_indices,
-                    )
+                        peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
+                        retained_energy = _total_energy(target, target_weights)
+                        ranking_score = (
+                            candidate_score[0],
+                            candidate_score[1],
+                            candidate_score[2],
+                            target_preference,
+                            -retained_energy,
+                            left.stable_id,
+                            right.stable_id,
+                            target_id,
+                            changed_indices,
+                        )
 
-                    adjustment = PairAdjustment(
-                        target_id=target_id,
-                        peer_id=peer_id,
-                        changed_indices=changed_indices,
-                        initial_overlap=pair_initial,
-                        final_overlap=pair_final,
-                        target_weights=target_weights,
-                        score=ranking_score,
-                    )
-                    if best is None or adjustment.score < best.score:
-                        best = adjustment
+                        adjustment = PairAdjustment(
+                            target_id=target_id,
+                            peer_id=peer_id,
+                            changed_indices=changed_indices,
+                            initial_overlap=pair_initial,
+                            final_overlap=pair_final,
+                            target_weights=target_weights,
+                            score=ranking_score,
+                        )
+                        if best is None or adjustment.score < best.score:
+                            best = adjustment
 
     return best
 

--- a/Database/backend/lora_block_orchestrator.py
+++ b/Database/backend/lora_block_orchestrator.py
@@ -12,7 +12,8 @@ from lora_energy_overlap import (
     dot_overlap,
 )
 
-MAX_SOFTENING_PASSES = 20
+MIN_SOFTENING_PASSES = 20
+SOFTENING_PASSES_PER_PAIR_BLOCK = 4
 OVERLAP_EPSILON = 1e-6
 
 
@@ -47,7 +48,19 @@ class LoraBlockOrchestratorOutput:
 
 
 AdjustableGroupKey = Tuple[str, str, int]
+GroupViolationScore = Tuple[float, int, float]
 WorstPair = Tuple[float, LoraBlockOrchestratorInput, LoraBlockOrchestratorInput]
+
+
+@dataclass(frozen=True)
+class PairAdjustment:
+    target_id: str
+    peer_id: str
+    changed_indices: Tuple[int, ...]
+    initial_overlap: float
+    final_overlap: float
+    target_weights: List[float]
+    score: Tuple[float, int, float, float, str, str, str, Tuple[int, ...]]
 
 
 def _same_adjustable_block_space(
@@ -131,6 +144,89 @@ def _choose_adjustment_target(
     return right if right.stable_id > left.stable_id else left
 
 
+def _candidate_pair_overlap(
+    *,
+    left: LoraBlockOrchestratorInput,
+    right: LoraBlockOrchestratorInput,
+    adjusted_weights: Dict[str, List[float]],
+    target_id: str,
+    target_weights: List[float],
+) -> float:
+    left_weights = target_weights if target_id == left.stable_id else adjusted_weights[left.stable_id]
+    right_weights = target_weights if target_id == right.stable_id else adjusted_weights[right.stable_id]
+    return _overlap_for_vectors(left, right, left_weights, right_weights)
+
+
+def _build_pair_adjustment_candidate(
+    *,
+    left: LoraBlockOrchestratorInput,
+    right: LoraBlockOrchestratorInput,
+    adjusted_weights: Dict[str, List[float]],
+    target: LoraBlockOrchestratorInput,
+    block_index: int,
+    overlap_threshold: float,
+) -> Optional[Tuple[str, Tuple[int, ...], float, float, List[float]]]:
+    initial_overlap = _overlap_for_vectors(
+        left,
+        right,
+        adjusted_weights[left.stable_id],
+        adjusted_weights[right.stable_id],
+    )
+    if initial_overlap <= overlap_threshold or initial_overlap <= 0.0:
+        return None
+
+    target_weights = list(adjusted_weights[target.stable_id])
+    original_value = target_weights[block_index]
+    if abs(original_value) <= 0.0:
+        return None
+
+    # First check whether removing this one block can get the pair below the
+    # threshold. If not, the zeroed value is still a candidate only when it
+    # improves the pair; group-level scoring decides whether it helps globally.
+    target_weights[block_index] = 0.0
+    zero_overlap = _candidate_pair_overlap(
+        left=left,
+        right=right,
+        adjusted_weights=adjusted_weights,
+        target_id=target.stable_id,
+        target_weights=target_weights,
+    )
+
+    if zero_overlap > overlap_threshold:
+        if zero_overlap < initial_overlap - OVERLAP_EPSILON:
+            return target.stable_id, (block_index,), initial_overlap, zero_overlap, target_weights
+        return None
+
+    # Binary-search the highest retained value for this block that keeps the
+    # measured pair cosine overlap at or below the threshold.
+    low = 0.0
+    high = 1.0
+    for _ in range(40):
+        mid = (low + high) / 2.0
+        target_weights[block_index] = original_value * mid
+        candidate_overlap = _candidate_pair_overlap(
+            left=left,
+            right=right,
+            adjusted_weights=adjusted_weights,
+            target_id=target.stable_id,
+            target_weights=target_weights,
+        )
+        if candidate_overlap <= overlap_threshold:
+            low = mid
+        else:
+            high = mid
+
+    target_weights[block_index] = original_value * low
+    final_overlap = _candidate_pair_overlap(
+        left=left,
+        right=right,
+        adjusted_weights=adjusted_weights,
+        target_id=target.stable_id,
+        target_weights=target_weights,
+    )
+    return target.stable_id, (block_index,), initial_overlap, final_overlap, target_weights
+
+
 def _reduce_pair_overlap(
     *,
     left: LoraBlockOrchestratorInput,
@@ -146,60 +242,164 @@ def _reduce_pair_overlap(
         return None, [], initial_overlap, initial_overlap
 
     target = _choose_adjustment_target(left, right, left_weights, right_weights)
-    target_weights = adjusted_weights[target.stable_id]
 
     # Reduce directionally important shared blocks first. This is deliberately
     # not uniform whole-vector scaling because cosine/L2 overlap is unchanged by
     # uniform scaling of one vector.
     contribution_by_index = sorted(
-        range(len(target_weights)),
+        range(len(adjusted_weights[target.stable_id])),
         key=lambda idx: (-(abs(left_weights[idx]) * abs(right_weights[idx])), idx),
     )
 
-    changed_indices: List[int] = []
-    current_overlap = initial_overlap
-
     for idx in contribution_by_index:
-        original_value = target_weights[idx]
-        if abs(original_value) <= 0.0:
+        candidate = _build_pair_adjustment_candidate(
+            left=left,
+            right=right,
+            adjusted_weights=adjusted_weights,
+            target=target,
+            block_index=idx,
+            overlap_threshold=overlap_threshold,
+        )
+        if candidate is None:
             continue
 
-        # First check whether removing this one block can get us below the
-        # threshold. If not, keep it removed only when it still improves overlap
-        # and continue to the next strongest shared block.
-        target_weights[idx] = 0.0
-        zero_overlap = _overlap_for_vectors(left, right, left_weights, right_weights)
+        target_id, changed_indices, _initial, final_overlap, target_weights = candidate
+        adjusted_weights[target_id] = target_weights
+        return target_id, list(changed_indices), initial_overlap, final_overlap
 
-        if zero_overlap > overlap_threshold:
-            if zero_overlap < current_overlap:
-                changed_indices.append(idx)
-                current_overlap = zero_overlap
-            else:
-                target_weights[idx] = original_value
-            continue
+    return None, [], initial_overlap, initial_overlap
 
-        # Binary-search the highest retained value for this block that keeps the
-        # measured cosine overlap at or below the threshold.
-        low = 0.0
-        high = 1.0
-        for _ in range(40):
-            mid = (low + high) / 2.0
-            target_weights[idx] = original_value * mid
-            candidate_overlap = _overlap_for_vectors(left, right, left_weights, right_weights)
-            if candidate_overlap <= overlap_threshold:
-                low = mid
-            else:
-                high = mid
 
-        target_weights[idx] = original_value * low
-        current_overlap = _overlap_for_vectors(left, right, left_weights, right_weights)
-        changed_indices.append(idx)
-        break
+def _weights_for_group_score(
+    entry: LoraBlockOrchestratorInput,
+    adjusted_weights: Dict[str, List[float]],
+    override: Optional[Tuple[str, List[float]]],
+) -> List[float]:
+    if override is not None and entry.stable_id == override[0]:
+        return override[1]
+    return adjusted_weights[entry.stable_id]
 
-    if not changed_indices:
-        return None, [], initial_overlap, current_overlap
 
-    return target.stable_id, changed_indices, initial_overlap, current_overlap
+def _group_violation_score(
+    group: List[LoraBlockOrchestratorInput],
+    adjusted_weights: Dict[str, List[float]],
+    *,
+    overlap_threshold: float,
+    override: Optional[Tuple[str, List[float]]] = None,
+) -> GroupViolationScore:
+    max_violation = 0.0
+    violation_count = 0
+    total_violation = 0.0
+
+    for left_pos, left in enumerate(group):
+        for right in group[left_pos + 1:]:
+            overlap = _overlap_for_vectors(
+                left,
+                right,
+                _weights_for_group_score(left, adjusted_weights, override),
+                _weights_for_group_score(right, adjusted_weights, override),
+            )
+            violation = overlap - overlap_threshold
+            if violation <= OVERLAP_EPSILON:
+                continue
+            max_violation = max(max_violation, violation)
+            violation_count += 1
+            total_violation += violation
+
+    return max_violation, violation_count, total_violation
+
+
+def _score_not_worse(
+    candidate: GroupViolationScore,
+    current: GroupViolationScore,
+) -> bool:
+    if candidate[0] < current[0] - OVERLAP_EPSILON:
+        return True
+    if candidate[0] > current[0] + OVERLAP_EPSILON:
+        return False
+    if candidate[1] != current[1]:
+        return candidate[1] < current[1]
+    return candidate[2] <= current[2] + OVERLAP_EPSILON
+
+
+def _choose_best_group_adjustment(
+    group: List[LoraBlockOrchestratorInput],
+    adjusted_weights: Dict[str, List[float]],
+    *,
+    overlap_threshold: float,
+) -> Optional[PairAdjustment]:
+    current_score = _group_violation_score(
+        group,
+        adjusted_weights,
+        overlap_threshold=overlap_threshold,
+    )
+    if current_score[1] == 0:
+        return None
+
+    best: Optional[PairAdjustment] = None
+
+    for left_pos, left in enumerate(group):
+        for right in group[left_pos + 1:]:
+            left_weights = adjusted_weights[left.stable_id]
+            right_weights = adjusted_weights[right.stable_id]
+            initial_overlap = _overlap_for_vectors(left, right, left_weights, right_weights)
+            if initial_overlap <= overlap_threshold + OVERLAP_EPSILON:
+                continue
+
+            target = _choose_adjustment_target(left, right, left_weights, right_weights)
+            contribution_by_index = sorted(
+                range(len(adjusted_weights[target.stable_id])),
+                key=lambda idx: (-(abs(left_weights[idx]) * abs(right_weights[idx])), idx),
+            )
+
+            for idx in contribution_by_index:
+                candidate = _build_pair_adjustment_candidate(
+                    left=left,
+                    right=right,
+                    adjusted_weights=adjusted_weights,
+                    target=target,
+                    block_index=idx,
+                    overlap_threshold=overlap_threshold,
+                )
+                if candidate is None:
+                    continue
+
+                target_id, changed_indices, pair_initial, pair_final, target_weights = candidate
+                candidate_score = _group_violation_score(
+                    group,
+                    adjusted_weights,
+                    overlap_threshold=overlap_threshold,
+                    override=(target_id, target_weights),
+                )
+                if not _score_not_worse(candidate_score, current_score):
+                    continue
+
+                peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
+                retained_energy = _total_energy(target, target_weights)
+                ranking_score = (
+                    candidate_score[0],
+                    candidate_score[1],
+                    candidate_score[2],
+                    -retained_energy,
+                    left.stable_id,
+                    right.stable_id,
+                    target_id,
+                    changed_indices,
+                )
+
+                adjustment = PairAdjustment(
+                    target_id=target_id,
+                    peer_id=peer_id,
+                    changed_indices=changed_indices,
+                    initial_overlap=pair_initial,
+                    final_overlap=pair_final,
+                    target_weights=target_weights,
+                    score=ranking_score,
+                )
+                if best is None or adjustment.score < best.score:
+                    best = adjustment
+
+    return best
 
 
 def _find_worst_violating_pair(
@@ -237,6 +437,20 @@ def _find_worst_violating_pair(
     return worst
 
 
+def _max_softening_passes_for_group(
+    group: List[LoraBlockOrchestratorInput],
+    *,
+    min_passes: int,
+) -> int:
+    if len(group) < 2:
+        return 0
+
+    pair_count = len(group) * (len(group) - 1) // 2
+    block_count = max(1, len(group[0].block_weights))
+    scaled_passes = pair_count * block_count * SOFTENING_PASSES_PER_PAIR_BLOCK
+    return max(min_passes, scaled_passes)
+
+
 def _format_softening_note(
     *,
     role: str,
@@ -244,7 +458,7 @@ def _format_softening_note(
     initial_overlap: float,
     final_overlap: float,
     overlap_threshold: float,
-    changed_indices: List[int],
+    changed_indices: Tuple[int, ...],
     pass_index: int,
 ) -> str:
     if final_overlap <= overlap_threshold + OVERLAP_EPSILON:
@@ -256,7 +470,7 @@ def _format_softening_note(
         f"Same-role ({role}) block overlap softening {outcome} against {peer_id}: "
         f"overlap={initial_overlap:.4f}->{final_overlap:.4f}, "
         f"threshold={overlap_threshold:.4f}, "
-        f"adjusted_blocks={changed_indices}, pass={pass_index}."
+        f"adjusted_blocks={list(changed_indices)}, pass={pass_index}."
     )
 
 
@@ -266,7 +480,7 @@ def _soften_same_role_overlaps(
     notes_by_id: Dict[str, List[str]],
     *,
     overlap_threshold: float = OVERLAP_THRESHOLD,
-    max_passes: int = MAX_SOFTENING_PASSES,
+    max_passes: int = MIN_SOFTENING_PASSES,
 ) -> None:
     groups: Dict[AdjustableGroupKey, List[LoraBlockOrchestratorInput]] = {}
     for entry in sorted(inputs, key=lambda item: item.stable_id):
@@ -280,57 +494,50 @@ def _soften_same_role_overlaps(
             continue
 
         passes_used = 0
-        for pass_index in range(1, max_passes + 1):
-            worst = _find_worst_violating_pair(
+        pass_budget = _max_softening_passes_for_group(group, min_passes=max_passes)
+        for pass_index in range(1, pass_budget + 1):
+            if _group_violation_score(
+                group,
+                adjusted_weights,
+                overlap_threshold=overlap_threshold,
+            )[1] == 0:
+                break
+
+            adjustment = _choose_best_group_adjustment(
                 group,
                 adjusted_weights,
                 overlap_threshold=overlap_threshold,
             )
-            if worst is None:
+            if adjustment is None:
+                remaining = _find_worst_violating_pair(
+                    group,
+                    adjusted_weights,
+                    overlap_threshold=overlap_threshold,
+                )
+                if remaining is not None:
+                    remaining_overlap, left, right = remaining
+                    note = (
+                        f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
+                        f"pair {left.stable_id}/{right.stable_id} remains overlap={remaining_overlap:.4f} "
+                        f"above threshold={overlap_threshold:.4f}; no group-improving block adjustment was found."
+                    )
+                    notes_by_id[left.stable_id].append(note)
+                    notes_by_id[right.stable_id].append(note)
                 break
 
             passes_used = pass_index
-            _worst_overlap, left, right = worst
-            target_id, changed_indices, initial_overlap, final_overlap = _reduce_pair_overlap(
-                left=left,
-                right=right,
-                adjusted_weights=adjusted_weights,
-                overlap_threshold=overlap_threshold,
-            )
-
-            if target_id is None:
-                notes_by_id[left.stable_id].append(
-                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
-                    f"pair {left.stable_id}/{right.stable_id} remains overlap={initial_overlap:.4f} "
-                    f"above threshold={overlap_threshold:.4f}; no lower-overlap block adjustment was found."
-                )
-                notes_by_id[right.stable_id].append(
-                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
-                    f"pair {left.stable_id}/{right.stable_id} remains overlap={initial_overlap:.4f} "
-                    f"above threshold={overlap_threshold:.4f}; no lower-overlap block adjustment was found."
-                )
-                break
-
-            peer_id = right.stable_id if target_id == left.stable_id else left.stable_id
-            notes_by_id[target_id].append(
+            adjusted_weights[adjustment.target_id] = list(adjustment.target_weights)
+            notes_by_id[adjustment.target_id].append(
                 _format_softening_note(
                     role=role,
-                    peer_id=peer_id,
-                    initial_overlap=initial_overlap,
-                    final_overlap=final_overlap,
+                    peer_id=adjustment.peer_id,
+                    initial_overlap=adjustment.initial_overlap,
+                    final_overlap=adjustment.final_overlap,
                     overlap_threshold=overlap_threshold,
-                    changed_indices=changed_indices,
+                    changed_indices=adjustment.changed_indices,
                     pass_index=pass_index,
                 )
             )
-
-            if final_overlap >= initial_overlap - OVERLAP_EPSILON:
-                notes_by_id[target_id].append(
-                    f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort: "
-                    f"latest adjustment did not materially reduce overlap "
-                    f"({initial_overlap:.4f}->{final_overlap:.4f})."
-                )
-                break
 
         remaining = _find_worst_violating_pair(
             group,
@@ -341,7 +548,7 @@ def _soften_same_role_overlaps(
             remaining_overlap, left, right = remaining
             note = (
                 f"Phase 8.5 same-role ({role}) block overlap softening stopped best-effort "
-                f"after {passes_used} pass(es): pair {left.stable_id}/{right.stable_id} "
+                f"after {passes_used} pass(es), budget={pass_budget}: pair {left.stable_id}/{right.stable_id} "
                 f"remains overlap={remaining_overlap:.4f} above threshold={overlap_threshold:.4f}."
             )
             notes_by_id[left.stable_id].append(note)

--- a/Database/backend/tests/test_lora_block_orchestrator.py
+++ b/Database/backend/tests/test_lora_block_orchestrator.py
@@ -1,3 +1,4 @@
+from itertools import combinations
 from pathlib import Path
 import sys
 
@@ -104,6 +105,51 @@ def test_orchestrator_softens_overlapping_same_role_block_vectors() -> None:
     assert final_overlap < initial_overlap
     assert final_overlap <= OVERLAP_THRESHOLD
     assert any("Same-role" in note for note in by_id["FLX-BBB-002"].notes)
+
+
+def test_orchestrator_rechecks_triplet_after_later_pair_adjustments() -> None:
+    inputs = [
+        _input(
+            "ID0",
+            role="character",
+            block_layout="flux_transformer_4",
+            strength_model=1.0,
+            weights=[0.2597, 4.7248, 2.6514, 2.1151],
+        ),
+        _input(
+            "ID1",
+            role="character",
+            block_layout="flux_transformer_4",
+            strength_model=1.0,
+            weights=[0.1184, 5.4682, 2.5122, 1.3267],
+        ),
+        _input(
+            "ID2",
+            role="character",
+            block_layout="flux_transformer_4",
+            strength_model=1.0,
+            weights=[0.4105, 1.5778, 3.5730, 1.1398],
+        ),
+    ]
+
+    assert _cosine_overlap(
+        inputs[0],
+        inputs[1],
+        inputs[0].block_weights,
+        inputs[1].block_weights,
+    ) > OVERLAP_THRESHOLD
+
+    outputs = orchestrate_lora_block_payloads(inputs)
+    by_id = {output.stable_id: output for output in outputs}
+
+    for left, right in combinations(inputs, 2):
+        final_overlap = _cosine_overlap(
+            left,
+            right,
+            by_id[left.stable_id].block_weights,
+            by_id[right.stable_id].block_weights,
+        )
+        assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
 
 
 def test_orchestrator_does_not_soften_different_roles() -> None:

--- a/Database/backend/tests/test_lora_block_orchestrator.py
+++ b/Database/backend/tests/test_lora_block_orchestrator.py
@@ -152,7 +152,6 @@ def test_orchestrator_rechecks_triplet_after_later_pair_adjustments() -> None:
         assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
 
 
-
 def test_orchestrator_converges_small_identical_group_without_fixed_cap() -> None:
     inputs = [
         _input(
@@ -182,6 +181,121 @@ def test_orchestrator_converges_small_identical_group_without_fixed_cap() -> Non
         for output in outputs
         for note in output.notes
     )
+
+
+def test_orchestrator_scores_zeroed_candidate_when_retained_value_worsens_group() -> None:
+    inputs = [
+        _input(
+            "ID0",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[0.4768965095, 2.8115012921, 0.5170393113],
+        ),
+        _input(
+            "ID1",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[0.1770078491, 0.3746271127, 0.1863345840],
+        ),
+        _input(
+            "ID2",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[2.4853668993, 2.1978300117, 3.4756357990],
+        ),
+    ]
+
+    assert _cosine_overlap(
+        inputs[0],
+        inputs[1],
+        inputs[0].block_weights,
+        inputs[1].block_weights,
+    ) > OVERLAP_THRESHOLD
+    assert _cosine_overlap(
+        inputs[1],
+        inputs[2],
+        inputs[1].block_weights,
+        inputs[2].block_weights,
+    ) > OVERLAP_THRESHOLD
+
+    outputs = orchestrate_lora_block_payloads(inputs)
+    by_id = {output.stable_id: output for output in outputs}
+
+    for left, right in combinations(inputs, 2):
+        final_overlap = _cosine_overlap(
+            left,
+            right,
+            by_id[left.stable_id].block_weights,
+            by_id[right.stable_id].block_weights,
+        )
+        assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
+
+    assert not any(
+        "stopped best-effort" in note
+        for output in outputs
+        for note in output.notes
+    )
+
+
+def test_orchestrator_scores_both_peers_before_best_effort_stop() -> None:
+    inputs = [
+        _input(
+            "ID0",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[0.5553307687, 0.3166328939, 4.1873228541],
+        ),
+        _input(
+            "ID1",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[2.9519184445, 0.7564664730, 1.2029105343],
+        ),
+        _input(
+            "ID2",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[1.3420440624, 0.5150427198, 1.7897945425],
+        ),
+    ]
+
+    assert _cosine_overlap(
+        inputs[0],
+        inputs[2],
+        inputs[0].block_weights,
+        inputs[2].block_weights,
+    ) > OVERLAP_THRESHOLD
+    assert _cosine_overlap(
+        inputs[1],
+        inputs[2],
+        inputs[1].block_weights,
+        inputs[2].block_weights,
+    ) > OVERLAP_THRESHOLD
+
+    outputs = orchestrate_lora_block_payloads(inputs)
+    by_id = {output.stable_id: output for output in outputs}
+
+    for left, right in combinations(inputs, 2):
+        final_overlap = _cosine_overlap(
+            left,
+            right,
+            by_id[left.stable_id].block_weights,
+            by_id[right.stable_id].block_weights,
+        )
+        assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
+
+    assert not any(
+        "stopped best-effort" in note
+        for output in outputs
+        for note in output.notes
+    )
+
 
 def test_orchestrator_does_not_soften_different_roles() -> None:
     outputs = orchestrate_lora_block_payloads([

--- a/Database/backend/tests/test_lora_block_orchestrator.py
+++ b/Database/backend/tests/test_lora_block_orchestrator.py
@@ -152,6 +152,37 @@ def test_orchestrator_rechecks_triplet_after_later_pair_adjustments() -> None:
         assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
 
 
+
+def test_orchestrator_converges_small_identical_group_without_fixed_cap() -> None:
+    inputs = [
+        _input(
+            f"ID{idx}",
+            role="character",
+            block_layout="flux_transformer_3",
+            strength_model=1.0,
+            weights=[1.0, 1.0, 1.0],
+        )
+        for idx in range(5)
+    ]
+
+    outputs = orchestrate_lora_block_payloads(inputs)
+    by_id = {output.stable_id: output for output in outputs}
+
+    for left, right in combinations(inputs, 2):
+        final_overlap = _cosine_overlap(
+            left,
+            right,
+            by_id[left.stable_id].block_weights,
+            by_id[right.stable_id].block_weights,
+        )
+        assert final_overlap <= OVERLAP_THRESHOLD + 1e-6
+
+    assert not any(
+        "stopped best-effort" in note
+        for output in outputs
+        for note in output.notes
+    )
+
 def test_orchestrator_does_not_soften_different_roles() -> None:
     outputs = orchestrate_lora_block_payloads([
         _input("FLX-AAA-001", role="character", weights=[1.0, 1.0, 0.2]),


### PR DESCRIPTION
## Summary

Fixes the Codex review findings from PR #45 / PR #46 around same-role overlap softening:

- A single forward pair pass could re-break earlier overlaps after later pair mutations.
- A fixed 20-pass cap could stop before small same-role groups converged.
- Returning only the threshold-tight retained value could miss a zeroed candidate that improves the whole group.
- Scoring only the preselected lower-energy target could miss a group-improving edit on the other peer.

This follow-up changes Phase 8.5 same-role softening into deterministic group-level relaxation with globally scored candidate adjustments and a scaled per-group pass budget.

## Changes

- Groups inputs by canonical role, block layout, and block-vector length.
- Ignores `other` roles, preserving the first-pass taxonomy guardrail.
- Repeatedly recomputes all pair overlaps in each group.
- Scores candidate block edits against the whole group, not only the currently selected pair.
- Scores both zeroed and threshold-tight retained block candidates when zeroing improves the selected pair.
- Scores candidates for both peers in each violating pair before declaring best-effort.
- Applies only group-non-worsening candidate adjustments.
- Uses a scaled pass budget based on pair count and block count:
  - `MIN_SOFTENING_PASSES = 20`
  - `SOFTENING_PASSES_PER_PAIR_BLOCK = 4`
- Keeps deterministic ordering and tie-breaks, preserving the older lower-energy/stable-id target preference when group scores tie.
- Updates notes to distinguish threshold reached from best-effort stopping.
- Adds regression coverage for:
  - Codex’s exact three-vector re-break example.
  - Five identical 3-block same-role LoRAs, proving the fixed-cap issue converges without best-effort notes.
  - A zeroed-candidate case where the retained value worsens the group.
  - A both-peer case where editing the non-preselected peer avoids best-effort stopping.

## Testing

Verified locally on Bender:

```text
python -m pytest -q tests/test_lora_block_orchestrator.py
```

Result:

```text
12 passed
```

Full targeted Phase 8.5/API smoke on Bender:

```text
python -m pytest -q tests/test_lora_block_orchestrator.py tests/test_phase85_contract.py tests/test_lora_energy_overlap.py tests/test_lora_combine_api.py
```

Result:

```text
25 passed, 1 xfailed
```

## Notes

PR #45 is already merged, so this remains a follow-up PR on top of `main` rather than a reopening of the previous PR. No Nibbler deploy or LoRA rescan is needed for review.