### PR TITLE
Phase 8.6: repair UI combine smoke test

### DIFF
--- a/Database/UI/src/App.smoke.test.jsx
+++ b/Database/UI/src/App.smoke.test.jsx
@@ -119,7 +119,8 @@ describe("App combine smoke", () => {
       const stack = within(selectedStack);
       expect(stack.getAllByText("sid-1").length).toBeGreaterThan(0);
       expect(stack.getAllByText("sid-2").length).toBeGreaterThan(0);
-      expect(stack.getByText(/0\.8000,0\.7000,0\.6000/i)).toBeTruthy();
+      expect(stack.getByText(/1\.0,0\.9,0\.8/i)).toBeTruthy();
+      expect(stack.getByText(/0\.7,0\.6,0\.5/i)).toBeTruthy();
     });
   });
 });

--- a/Database/UI/src/App.smoke.test.jsx
+++ b/Database/UI/src/App.smoke.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import App from "./App";
 
@@ -25,6 +25,9 @@ describe("App combine smoke", () => {
               stable_id: "sid-1",
               filename: "demo-lora-1.safetensors",
               file_path: "/tmp/demo-lora-1.safetensors",
+              base_model_code: "FLX",
+              category_code: "STL",
+              role: "style",
               has_block_weights: true,
               block_layout: "flux_fallback_16",
             },
@@ -33,6 +36,9 @@ describe("App combine smoke", () => {
               stable_id: "sid-2",
               filename: "demo-lora-2.safetensors",
               file_path: "/tmp/demo-lora-2.safetensors",
+              base_model_code: "FLX",
+              category_code: "STL",
+              role: "style",
               has_block_weights: true,
               block_layout: "flux_fallback_16",
             },
@@ -43,22 +49,46 @@ describe("App combine smoke", () => {
 
       if (url.endsWith("/lora/combine") && init?.method === "POST") {
         return jsonResponse({
+          response_schema_version: "7.1",
+          compatible: true,
           validated_base_model: "FLX",
           validated_layout: "flux_fallback_16",
-          warnings: [],
+          included_loras: ["sid-1", "sid-2"],
           excluded_loras: [],
+          reasons: [],
+          warnings: [],
           combined: {
-            "sid-1": {
+            strength_model: 1.0,
+            strength_clip: null,
+            block_weights: [0.85, 0.75, 0.65],
+            block_weights_csv: "0.8500,0.7500,0.6500",
+          },
+          node_payloads: [
+            {
+              stable_id: "sid-1",
+              filename: "demo-lora-1.safetensors",
+              role: "style",
+              base_model_code: "FLX",
+              block_layout: "flux_fallback_16",
               strength_model: 0.8,
-              strength_clip: 1,
-              block_weights: [1, 0.9, 0.8],
+              strength_clip: 1.0,
+              block_weights: [1.0, 0.9, 0.8],
+              block_weights_csv: "1.0000,0.9000,0.8000",
+              orchestration_notes: ["Phase 8.5 smoke note for sid-1"],
             },
-            "sid-2": {
+            {
+              stable_id: "sid-2",
+              filename: "demo-lora-2.safetensors",
+              role: "style",
+              base_model_code: "FLX",
+              block_layout: "flux_fallback_16",
               strength_model: 0.6,
               strength_clip: 0.9,
               block_weights: [0.7, 0.6, 0.5],
+              block_weights_csv: "0.7000,0.6000,0.5000",
+              orchestration_notes: ["Phase 8.5 smoke note for sid-2"],
             },
-          },
+          ],
         });
       }
 
@@ -75,16 +105,21 @@ describe("App combine smoke", () => {
 
     expect(await screen.findByText(/LoRA catalog/i)).toBeTruthy();
 
-    fireEvent.click(await screen.findByLabelText("Select sid-1"));
-    fireEvent.click(await screen.findByLabelText("Select sid-2"));
-
     fireEvent.click(screen.getByRole("tab", { name: "Combine" }));
-    fireEvent.click(screen.getByRole("button", { name: "Calculate configuration" }));
+
+    fireEvent.click(await screen.findByText("sid-1"));
+    fireEvent.click(await screen.findByText("sid-2"));
+
+    fireEvent.click(screen.getByRole("button", { name: /calculate/i }));
 
     await waitFor(() => {
-      expect(screen.getAllByText("sid-1").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("sid-2").length).toBeGreaterThan(0);
-      expect(screen.getByText(/strength_model: 0.8/i)).toBeTruthy();
+      const selectedStack = screen.getByText(/Selected stack/i).closest("section");
+      expect(selectedStack).toBeTruthy();
+
+      const stack = within(selectedStack);
+      expect(stack.getAllByText("sid-1").length).toBeGreaterThan(0);
+      expect(stack.getAllByText("sid-2").length).toBeGreaterThan(0);
+      expect(stack.getByText(/0\.8000,0\.7000,0\.6000/i)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary

Repairs the stale UI combine smoke test so it matches the current Combine workflow.

## Changes

- Switches to the Combine tab before selecting cards.
- Selects LoRAs by clicking rendered card IDs instead of old `Select <stable_id>` labels.
- Uses the current `/api/lora/combine` response shape with `node_payloads`.
- Asserts the currently displayed one-decimal block-weight strings.

## Testing

Verified locally on Bender:

```text
cd E:\LoRA Project\Database\UI
npm test -- --run
```

Result:

```text
1 passed
```

## Notes

This is a test-only repair after restoring `main` from the accidental UI overwrite commit. No app behaviour changes are included.