### PR TITLE
Phase 8.6: preserve structured combine errors for stack health

### DIFF
--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -1507,7 +1507,26 @@ function App() {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(bannerString(err.detail ?? err.message ?? err) || `Combine failed (${res.status})`);
+        const detail = err.detail ?? err;
+        const structuredDetail = detail && typeof detail === "object" && !Array.isArray(detail) ? detail : null;
+
+        if (structuredDetail) {
+          setCombineResult(structuredDetail);
+          setCombineComputedById(buildCombineComputedById(structuredDetail));
+        } else {
+          setCombineResult(null);
+          setCombineComputedById(new Map());
+        }
+
+        const structuredMessage =
+          Array.isArray(structuredDetail?.warnings) && structuredDetail.warnings.length > 0
+            ? structuredDetail.warnings[0]
+            : Array.isArray(structuredDetail?.reasons) && structuredDetail.reasons.length > 0
+              ? structuredDetail.reasons[0]
+              : null;
+
+        setCombineError(bannerString(structuredMessage ?? detail ?? err.message ?? err) || `Combine failed (${res.status})`);
+        return;
       }
 
       const data = await res.json();


### PR DESCRIPTION
## Summary

Follow-up to PR #48. Restores the missing app-side handling for structured `/api/lora/combine` errors so the new Stack Health panel can render for incompatible or all-excluded stacks.

## Changes

- Preserves structured non-2xx combine details in `combineResult`.
- Builds `combineComputedById` from structured detail when possible.
- Keeps the error banner readable by preferring warning/reason text instead of rendering the full JSON object.
- Leaves backend behaviour, DB schema, and scanning untouched.

## Testing

Verified locally on Bender:

```text
cd E:\LoRA Project\Database\UI
npm test -- --run
```

Result:

```text
1 passed file
2 passed tests
```

## Notes

This fixes the structured-error Stack Health path that Codex flagged after PR #48.