### PR TITLE
Phase 8.7: add role policy foundation

### DIFF
--- a/Database/backend/lora_role_policy.py
+++ b/Database/backend/lora_role_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from lora_energy_overlap import ROLE_HIERARCHY, canonicalize_role
+
+
+@dataclass(frozen=True)
+class LoRARolePolicy:
+    role: str
+    priority: int
+    default_model_strength: float
+    default_clip_strength: float
+    intent_label: str
+    protects_identity: bool = False
+    preserves_composition: bool = False
+    treat_as_flavour: bool = False
+
+
+ROLE_POLICIES: Dict[str, LoRARolePolicy] = {
+    "character": LoRARolePolicy(
+        role="character",
+        priority=100,
+        default_model_strength=0.90,
+        default_clip_strength=0.70,
+        intent_label="identity anchor",
+        protects_identity=True,
+    ),
+    "style": LoRARolePolicy(
+        role="style",
+        priority=70,
+        default_model_strength=0.60,
+        default_clip_strength=0.40,
+        intent_label="look / flavour",
+        treat_as_flavour=True,
+    ),
+    "clothing": LoRARolePolicy(
+        role="clothing",
+        priority=75,
+        default_model_strength=0.65,
+        default_clip_strength=0.45,
+        intent_label="outfit detail",
+    ),
+    "environment": LoRARolePolicy(
+        role="environment",
+        priority=50,
+        default_model_strength=0.45,
+        default_clip_strength=0.30,
+        intent_label="scene context",
+        preserves_composition=True,
+    ),
+    "utility": LoRARolePolicy(
+        role="utility",
+        priority=40,
+        default_model_strength=0.35,
+        default_clip_strength=0.00,
+        intent_label="helper / detail / pose",
+        preserves_composition=True,
+    ),
+    "other": LoRARolePolicy(
+        role="other",
+        priority=20,
+        default_model_strength=0.30,
+        default_clip_strength=0.00,
+        intent_label="unknown intent",
+    ),
+}
+
+
+def get_role_policy(role: str) -> LoRARolePolicy:
+    """Return the deterministic advisory policy for a folder-derived role.
+
+    This is an advisory layer only. It does not override scanned tensor facts,
+    folder-derived role, explicit user settings, or the overlap engine.
+    """
+
+    canonical_role = canonicalize_role(role)
+    return ROLE_POLICIES[canonical_role]
+
+
+def list_role_policies() -> Tuple[LoRARolePolicy, ...]:
+    """Return policies in canonical role hierarchy order."""
+
+    return tuple(ROLE_POLICIES[role] for role in ROLE_HIERARCHY)

--- a/Database/backend/tests/test_lora_role_policy.py
+++ b/Database/backend/tests/test_lora_role_policy.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from lora_role_policy import get_role_policy, list_role_policies  # noqa: E402
+
+
+def test_role_policy_returns_character_as_identity_anchor():
+    policy = get_role_policy("character")
+
+    assert policy.role == "character"
+    assert policy.priority == 100
+    assert policy.default_model_strength == 0.90
+    assert policy.default_clip_strength == 0.70
+    assert policy.intent_label == "identity anchor"
+    assert policy.protects_identity is True
+
+
+def test_role_policy_canonicalizes_action_and_pose_to_utility():
+    action = get_role_policy("action")
+    pose = get_role_policy("pose")
+
+    assert action.role == "utility"
+    assert pose.role == "utility"
+    assert action.default_model_strength == 0.35
+    assert pose.default_clip_strength == 0.00
+    assert action.preserves_composition is True
+
+
+def test_role_policy_defaults_unknown_roles_to_other():
+    policy = get_role_policy("weird-folder-name")
+
+    assert policy.role == "other"
+    assert policy.priority == 20
+    assert policy.intent_label == "unknown intent"
+
+
+def test_role_policies_follow_existing_role_hierarchy_order():
+    policies = list_role_policies()
+
+    assert [policy.role for policy in policies] == [
+        "character",
+        "style",
+        "clothing",
+        "environment",
+        "utility",
+        "other",
+    ]
+
+
+def test_role_policy_priorities_encode_non_equal_artist_intent():
+    character = get_role_policy("character")
+    clothing = get_role_policy("clothing")
+    style = get_role_policy("style")
+    utility = get_role_policy("utility")
+
+    assert character.priority > clothing.priority > style.priority > utility.priority
+    assert character.protects_identity is True
+    assert style.treat_as_flavour is True


### PR DESCRIPTION
## Summary

Adds the first Phase 8.7 backend-only role intelligence foundation.

## Changes

- Adds `lora_role_policy.py` with deterministic advisory policies for canonical roles.
- Encodes role priorities and default advisory model/clip strengths.
- Marks character as identity-protecting, style as flavour-capable, and utility/environment as composition-preserving where appropriate.
- Reuses existing `canonicalize_role` and `ROLE_HIERARCHY` from `lora_energy_overlap`.
- Adds tests for character anchor behaviour, action/pose canonicalisation, unknown-role fallback, hierarchy order, and non-equal artist-intent priorities.

## Testing

Verified locally on Bender:

```text
cd E:\LoRA Project
.\.venv\Scripts\python.exe -m pytest -q Database\backend\tests\test_lora_role_policy.py Database\backend\tests\test_lora_energy_overlap.py
```

Result:

```text
9 passed
```

## Notes

This does not change combine maths, API responses, UI behaviour, DB schema, scanning, or deployed runtime behaviour yet. It only adds the deterministic advisory role-policy layer that later Phase 8.7 slices can consume.