### PR TITLE
Phase 8.7: show role policy intent in combine UI

### DIFF
--- a/Database/UI/src/App.css
+++ b/Database/UI/src/App.css
@@ -1589,3 +1589,47 @@ button.lm-main-pill:disabled {
   margin-top: 4px;
 }
 
+.lm-role-policy {
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 12px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.lm-role-policy-main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: #dbeafe;
+}
+
+.lm-role-policy-priority {
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  padding: 2px 7px;
+  font-size: 10px;
+  color: #bfdbfe;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.lm-role-policy-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.lm-role-policy-flags span {
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  padding: 2px 7px;
+  font-size: 10px;
+  color: #93c5fd;
+}
+

--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -432,6 +432,15 @@ function CombineSelectedCard({ item, computed, recommendedModel, recommendedClip
   const displayName = rawFilename.replace(/\.safetensors$/i, "");
 
   const isTamed = recommendedModel !== null && recommendedModel !== undefined;
+  const rolePolicy = computed?.role_policy && typeof computed.role_policy === "object" ? computed.role_policy : null;
+  const hasRolePolicy = Boolean(rolePolicy?.intent_label);
+  const rolePolicyFlags = rolePolicy
+    ? [
+        rolePolicy.protects_identity ? "protects identity" : null,
+        rolePolicy.preserves_composition ? "preserves composition" : null,
+        rolePolicy.treat_as_flavour ? "flavour layer" : null,
+      ].filter(Boolean)
+    : [];
   const orchestrationNotes = Array.isArray(computed?.orchestration_notes)
     ? computed.orchestration_notes.filter(Boolean)
     : [];
@@ -486,6 +495,25 @@ function CombineSelectedCard({ item, computed, recommendedModel, recommendedClip
           </div>
         </div>
       </div>
+
+      {hasRolePolicy && (
+        <div className="lm-role-policy">
+          <div className="lm-combine-strength-label">role intent</div>
+          <div className="lm-role-policy-main">
+            <span>{rolePolicy.intent_label}</span>
+            {Number.isFinite(Number(rolePolicy.priority)) && (
+              <span className="lm-role-policy-priority">priority {Number(rolePolicy.priority)}</span>
+            )}
+          </div>
+          {rolePolicyFlags.length > 0 && (
+            <div className="lm-role-policy-flags">
+              {rolePolicyFlags.map((flag) => (
+                <span key={`${sid}-role-policy-${flag}`}>{flag}</span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {hasOrchestrationNotes && (
         <div className="lm-orchestration-notes">


### PR DESCRIPTION
## Summary

Adds UI display for the role policy metadata returned by `/api/lora/combine`.

## Changes

- Shows role intent on selected Combine cards when `role_policy` exists.
- Displays intent label, priority, and role flags.
- Adds CSS for the role policy panel.
- Updates the UI smoke test for the visible role intent strip.

## Testing

Verified locally on Bender:

```text
cd E:\LoRA Project\Database\UI
npm test -- --run

Result:
1 passed file
2 passed tests
Notes

UI-only. No backend maths, DB, scan, or deployment changes.