### PR TITLE
Phase 8.8: add role-aware recommendation notes

### DIFF
--- a/Database/backend/lora_api_server.py
+++ b/Database/backend/lora_api_server.py
@@ -40,7 +40,7 @@ from lora_energy_overlap import (
     allocate_strengths_with_role_budget_and_overlap,
     compute_lora_energy_metrics,
 )
-from lora_role_policy import get_role_policy
+from lora_role_policy import build_role_recommendation_notes, get_role_policy
 from lora_block_orchestrator import (
     LoraBlockOrchestratorInput,
     orchestrate_lora_block_payloads,
@@ -763,6 +763,7 @@ def _build_node_payloads(
         b_out: Optional[float] = None if b_val is None else float(b_val)
 
         role_policy = get_role_policy(payload.role)
+        role_recommendation_notes = list(build_role_recommendation_notes(payload.role))
         node_payloads.append(
             {
                 "stable_id": stable_id,
@@ -778,7 +779,8 @@ def _build_node_payloads(
                 "B": b_out,
                 "block_weights": payload.block_weights,
                 "block_weights_csv": payload.block_weights_csv,
-                "orchestration_notes": payload.notes,
+                "orchestration_notes": payload.notes + role_recommendation_notes,
+                "role_recommendation_notes": role_recommendation_notes,
                 "role_policy": {
                     "priority": role_policy.priority,
                     "intent_label": role_policy.intent_label,

--- a/Database/backend/lora_role_policy.py
+++ b/Database/backend/lora_role_policy.py
@@ -83,3 +83,43 @@ def list_role_policies() -> Tuple[LoRARolePolicy, ...]:
     """Return policies in canonical role hierarchy order."""
 
     return tuple(ROLE_POLICIES[role] for role in ROLE_HIERARCHY)
+
+
+def build_role_recommendation_notes(role: str) -> Tuple[str, ...]:
+    """Return advisory, non-mutating recommendation notes for a role.
+
+    These notes explain how a role should be considered by later recommendation
+    logic. They deliberately do not change strengths or block weights.
+    """
+
+    policy = get_role_policy(role)
+    notes = [
+        f"Phase 8.8: role policy marks this LoRA as {policy.intent_label}; recommendations are advisory only."
+    ]
+
+    if policy.protects_identity:
+        notes.append(
+            "Phase 8.8: identity anchor detected; preserve character influence unless explicit overlap handling requires softening."
+        )
+
+    if policy.treat_as_flavour:
+        notes.append(
+            "Phase 8.8: flavour layer detected; keep it supportive so it does not overpower identity or outfit anchors."
+        )
+
+    if policy.preserves_composition:
+        notes.append(
+            "Phase 8.8: composition-preserving helper detected; prefer lower supportive strength unless the user boosts it."
+        )
+
+    if policy.role == "clothing":
+        notes.append(
+            "Phase 8.8: outfit detail role detected; allow moderate influence while avoiding identity collision."
+        )
+
+    if policy.role == "other":
+        notes.append(
+            "Phase 8.8: unknown role detected; keep conservative defaults until the LoRA intent is clearer."
+        )
+
+    return tuple(notes)

--- a/Database/backend/tests/test_lora_combine_api.py
+++ b/Database/backend/tests/test_lora_combine_api.py
@@ -252,10 +252,14 @@ def test_combine_response_includes_aliases_and_csv_consistency_for_model_and_cli
             "block_weights",
             "block_weights_csv",
             "orchestration_notes",
+            "role_recommendation_notes",
             "role_policy",
         } <= set(payload.keys())
         assert isinstance(payload["orchestration_notes"], list)
         assert payload["orchestration_notes"]
+        assert isinstance(payload["role_recommendation_notes"], list)
+        assert payload["role_recommendation_notes"]
+        assert any("Phase 8.8:" in note for note in payload["role_recommendation_notes"])
         assert {
             "priority",
             "intent_label",
@@ -285,6 +289,12 @@ def test_combine_response_includes_aliases_and_csv_consistency_for_model_and_cli
     }
     assert role_policy_by_id["FLX-REAL-001"]["intent_label"] == "unknown intent"
     assert role_policy_by_id["FLX-REAL-001"]["priority"] == 20
+
+    notes_by_id = {
+        payload["stable_id"]: payload["role_recommendation_notes"]
+        for payload in body["node_payloads"]
+    }
+    assert any("unknown role detected" in note for note in notes_by_id["FLX-REAL-001"])
 
     assert body["excluded_loras"] == []
     assert body["reasons"] == []

--- a/Database/backend/tests/test_lora_role_policy.py
+++ b/Database/backend/tests/test_lora_role_policy.py
@@ -3,7 +3,11 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from lora_role_policy import get_role_policy, list_role_policies  # noqa: E402
+from lora_role_policy import (  # noqa: E402
+    build_role_recommendation_notes,
+    get_role_policy,
+    list_role_policies,
+)
 
 
 def test_role_policy_returns_character_as_identity_anchor():
@@ -58,3 +62,16 @@ def test_role_policy_priorities_encode_non_equal_artist_intent():
     assert character.priority > clothing.priority > style.priority > utility.priority
     assert character.protects_identity is True
     assert style.treat_as_flavour is True
+
+
+def test_role_recommendation_notes_are_advisory_and_role_specific():
+    character_notes = build_role_recommendation_notes("character")
+    style_notes = build_role_recommendation_notes("style")
+    utility_notes = build_role_recommendation_notes("utility")
+    other_notes = build_role_recommendation_notes("not-a-known-role")
+
+    assert any("advisory only" in note for note in character_notes)
+    assert any("identity anchor detected" in note for note in character_notes)
+    assert any("flavour layer detected" in note for note in style_notes)
+    assert any("composition-preserving helper detected" in note for note in utility_notes)
+    assert any("unknown role detected" in note for note in other_notes)


### PR DESCRIPTION
## Summary

Adds advisory role-aware recommendation notes for combine payloads.

## Changes

- Adds role-specific advisory note generation in `lora_role_policy.py`.
- Wires role recommendation notes into each combine `node_payload`.
- Adds `role_recommendation_notes` as a dedicated payload field.
- Extends backend tests for role-specific advisory notes and combine payload coverage.

## Testing

Verified locally on Bender:

```text
cd E:\LoRA Project
.\.venv\Scripts\python.exe -m pytest -q Database\backend\tests\test_lora_role_policy.py Database\backend\tests\test_lora_combine_api.py
```

Result:

```text
14 passed
```

## Notes

This is advisory only. It does not change strengths, block weights, overlap handling, DB schema, scanning, or UI behaviour.