### PR TITLE
Phase 8.8b: add advisory role strength recommendations

### DIFF
--- a/Database/backend/lora_role_policy.py
+++ b/Database/backend/lora_role_policy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 from lora_energy_overlap import ROLE_HIERARCHY, canonicalize_role
 
@@ -16,6 +16,44 @@ class LoRARolePolicy:
     protects_identity: bool = False
     preserves_composition: bool = False
     treat_as_flavour: bool = False
+
+
+@dataclass(frozen=True)
+class LoRARoleStrengthRecommendation:
+    """Advisory role-aware strength recommendation.
+
+    Phase 8.8b contract:
+    - This is recommendation metadata only.
+    - It does not mutate requested strengths, corrected strengths, block weights,
+      overlap handling, clip enforcement, or composer maths.
+    """
+
+    role: str
+    requested_model_strength: float
+    overlap_corrected_model_strength: float
+    role_default_model_strength: float
+    recommended_model_strength: float
+    requested_clip_strength: float
+    role_default_clip_strength: float
+    recommended_clip_strength: float
+    clip_contributor: bool
+    applied_to_math: bool = False
+    basis: str = "role_policy_advisory"
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "role": self.role,
+            "requested_model_strength": self.requested_model_strength,
+            "overlap_corrected_model_strength": self.overlap_corrected_model_strength,
+            "role_default_model_strength": self.role_default_model_strength,
+            "recommended_model_strength": self.recommended_model_strength,
+            "requested_clip_strength": self.requested_clip_strength,
+            "role_default_clip_strength": self.role_default_clip_strength,
+            "recommended_clip_strength": self.recommended_clip_strength,
+            "clip_contributor": self.clip_contributor,
+            "applied_to_math": self.applied_to_math,
+            "basis": self.basis,
+        }
 
 
 ROLE_POLICIES: Dict[str, LoRARolePolicy] = {
@@ -83,6 +121,39 @@ def list_role_policies() -> Tuple[LoRARolePolicy, ...]:
     """Return policies in canonical role hierarchy order."""
 
     return tuple(ROLE_POLICIES[role] for role in ROLE_HIERARCHY)
+
+
+def build_role_strength_recommendation(
+    role: str,
+    *,
+    requested_model_strength: float,
+    overlap_corrected_model_strength: float,
+    requested_clip_strength: float = 0.0,
+    clip_contributor: bool = False,
+) -> LoRARoleStrengthRecommendation:
+    """Build advisory role-aware strength targets for a LoRA.
+
+    The recommendation deliberately uses role defaults as the target values while
+    preserving both the raw requested model strength and the overlap-corrected
+    model strength for later UI/explanation work.
+    """
+
+    policy = get_role_policy(role)
+    recommended_clip_strength = policy.default_clip_strength if clip_contributor else 0.0
+
+    return LoRARoleStrengthRecommendation(
+        role=policy.role,
+        requested_model_strength=float(requested_model_strength),
+        overlap_corrected_model_strength=float(overlap_corrected_model_strength),
+        role_default_model_strength=float(policy.default_model_strength),
+        recommended_model_strength=float(policy.default_model_strength),
+        requested_clip_strength=float(requested_clip_strength),
+        role_default_clip_strength=float(policy.default_clip_strength),
+        recommended_clip_strength=float(recommended_clip_strength),
+        clip_contributor=bool(clip_contributor),
+        applied_to_math=False,
+        basis="role_policy_advisory",
+    )
 
 
 def build_role_recommendation_notes(role: str) -> Tuple[str, ...]:

--- a/Database/backend/tests/test_lora_role_policy.py
+++ b/Database/backend/tests/test_lora_role_policy.py
@@ -5,6 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from lora_role_policy import (  # noqa: E402
     build_role_recommendation_notes,
+    build_role_strength_recommendation,
     get_role_policy,
     list_role_policies,
 )
@@ -75,3 +76,65 @@ def test_role_recommendation_notes_are_advisory_and_role_specific():
     assert any("flavour layer detected" in note for note in style_notes)
     assert any("composition-preserving helper detected" in note for note in utility_notes)
     assert any("unknown role detected" in note for note in other_notes)
+
+
+def test_role_strength_recommendation_is_advisory_only_for_character():
+    recommendation = build_role_strength_recommendation(
+        "character",
+        requested_model_strength=1.25,
+        overlap_corrected_model_strength=0.42,
+        requested_clip_strength=0.33,
+        clip_contributor=True,
+    )
+
+    assert recommendation.role == "character"
+    assert recommendation.requested_model_strength == 1.25
+    assert recommendation.overlap_corrected_model_strength == 0.42
+    assert recommendation.role_default_model_strength == 0.90
+    assert recommendation.recommended_model_strength == 0.90
+    assert recommendation.requested_clip_strength == 0.33
+    assert recommendation.role_default_clip_strength == 0.70
+    assert recommendation.recommended_clip_strength == 0.70
+    assert recommendation.clip_contributor is True
+    assert recommendation.applied_to_math is False
+    assert recommendation.basis == "role_policy_advisory"
+
+
+def test_role_strength_recommendation_disables_clip_for_non_clip_contributors():
+    recommendation = build_role_strength_recommendation(
+        "style",
+        requested_model_strength=1.0,
+        overlap_corrected_model_strength=0.25,
+        requested_clip_strength=0.99,
+        clip_contributor=False,
+    )
+
+    assert recommendation.role == "style"
+    assert recommendation.role_default_clip_strength == 0.40
+    assert recommendation.recommended_clip_strength == 0.0
+    assert recommendation.clip_contributor is False
+    assert recommendation.applied_to_math is False
+
+
+def test_role_strength_recommendation_payload_is_stable_and_explicit():
+    payload = build_role_strength_recommendation(
+        "pose",
+        requested_model_strength=0.8,
+        overlap_corrected_model_strength=0.2,
+        requested_clip_strength=0.5,
+        clip_contributor=True,
+    ).to_payload()
+
+    assert payload == {
+        "role": "utility",
+        "requested_model_strength": 0.8,
+        "overlap_corrected_model_strength": 0.2,
+        "role_default_model_strength": 0.35,
+        "recommended_model_strength": 0.35,
+        "requested_clip_strength": 0.5,
+        "role_default_clip_strength": 0.0,
+        "recommended_clip_strength": 0.0,
+        "clip_contributor": True,
+        "applied_to_math": False,
+        "basis": "role_policy_advisory",
+    }


### PR DESCRIPTION
## Summary

Adds a conservative Phase 8.8b backend contract for advisory role-aware strength recommendations.

## Changes

- Adds `LoRARoleStrengthRecommendation` to `lora_role_policy.py`.
- Adds `build_role_strength_recommendation(...)` helper.
- Keeps recommendations explicitly advisory with `applied_to_math: false`.
- Preserves requested model strength and overlap-corrected model strength for future UI/explanation work.
- Recommends role-default model strength from existing role policy defaults.
- Recommends role-default clip strength only when the LoRA is a clip contributor.
- Adds tests for character, style, pose/utility canonicalisation, payload shape, and non-clip contributor behaviour.

## Intent

This PR deliberately does **not** change actual combine maths, block weights, overlap softening, DB schema, scanning, deployment, or UI behaviour. It creates the tested contract we can wire into node payloads/UI next.

## Testing

Please verify locally on Bender:

```text
cd "E:\LoRA Project"
.\.venv\Scripts\python.exe -m pytest -q Database\backend\tests\test_lora_role_policy.py
```

Expected: all role policy tests pass.