### PR TITLE
Phase 8.8c: expose role strength recommendations in combine payloads

### DIFF
--- a/Database/backend/lora_api_server.py
+++ b/Database/backend/lora_api_server.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import csv
 import io
@@ -40,7 +40,11 @@ from lora_energy_overlap import (
     allocate_strengths_with_role_budget_and_overlap,
     compute_lora_energy_metrics,
 )
-from lora_role_policy import build_role_recommendation_notes, get_role_policy
+from lora_role_policy import (
+    build_role_recommendation_notes,
+    build_role_strength_recommendation,
+    get_role_policy,
+)
 from lora_block_orchestrator import (
     LoraBlockOrchestratorInput,
     orchestrate_lora_block_payloads,
@@ -764,6 +768,13 @@ def _build_node_payloads(
 
         role_policy = get_role_policy(payload.role)
         role_recommendation_notes = list(build_role_recommendation_notes(payload.role))
+        role_strength_recommendation = build_role_strength_recommendation(
+            payload.role,
+            requested_model_strength=float(cfg.get("_requested_model_strength", payload.strength_model)),
+            overlap_corrected_model_strength=payload.strength_model,
+            requested_clip_strength=float(cfg.get("_requested_clip_strength", cfg.get("strength_clip", 0.0))),
+            clip_contributor=payload.text_encoder_contributor,
+        ).to_payload()
         node_payloads.append(
             {
                 "stable_id": stable_id,
@@ -781,6 +792,7 @@ def _build_node_payloads(
                 "block_weights_csv": payload.block_weights_csv,
                 "orchestration_notes": payload.notes + role_recommendation_notes,
                 "role_recommendation_notes": role_recommendation_notes,
+                "role_strength_recommendation": role_strength_recommendation,
                 "role_policy": {
                     "priority": role_policy.priority,
                     "intent_label": role_policy.intent_label,
@@ -1033,6 +1045,8 @@ def api_lora_combine(body: LoRACombineRequest):
                 )
             role = derive_role_from_path(file_path_value or "")
             raw_strength_model = float(cfg.get("strength_model", 1.0))
+            cfg["_requested_model_strength"] = raw_strength_model
+            cfg["_requested_clip_strength"] = float(cfg.get("strength_clip", 0.0))
             energy_inputs.append(
                 LoRAEnergyInput(
                     stable_id=lora.stable_id,

--- a/Database/backend/tests/test_lora_combine_api.py
+++ b/Database/backend/tests/test_lora_combine_api.py
@@ -253,6 +253,7 @@ def test_combine_response_includes_aliases_and_csv_consistency_for_model_and_cli
             "block_weights_csv",
             "orchestration_notes",
             "role_recommendation_notes",
+            "role_strength_recommendation",
             "role_policy",
         } <= set(payload.keys())
         assert isinstance(payload["orchestration_notes"], list)
@@ -260,6 +261,15 @@ def test_combine_response_includes_aliases_and_csv_consistency_for_model_and_cli
         assert isinstance(payload["role_recommendation_notes"], list)
         assert payload["role_recommendation_notes"]
         assert any("Phase 8.8:" in note for note in payload["role_recommendation_notes"])
+
+        recommendation = payload["role_strength_recommendation"]
+        assert recommendation["applied_to_math"] is False
+        assert recommendation["basis"] == "role_policy_advisory"
+        assert recommendation["recommended_model_strength"] == recommendation["role_default_model_strength"]
+        assert recommendation["clip_contributor"] == payload["clip_contributor"]
+        assert "requested_model_strength" in recommendation
+        assert "overlap_corrected_model_strength" in recommendation
+
         assert {
             "priority",
             "intent_label",


### PR DESCRIPTION
## Summary

Wires the Phase 8.8b advisory role strength recommendation contract into `/api/lora/combine` node payloads.

## Changes

- Imports `build_role_strength_recommendation` in `lora_api_server.py`.
- Preserves each LoRA's requested model and clip strengths before overlap/budget correction.
- Adds `role_strength_recommendation` to each combine `node_payload`.
- Keeps `applied_to_math: false` so recommendations remain advisory-only.
- Extends combine API tests to assert the recommendation payload exists, is explicit, and remains non-mutating.

## Intent

This is still advisory-only. It does not change actual combine maths, block weights, overlap softening, DB schema, scanning, deployment, or UI behaviour.

## Testing

Verified locally on Bender:

```text
cd "E:\LoRA Project"
.\.venv\Scripts\python.exe -m pytest -q Database\backend\tests\test_lora_role_policy.py Database\backend\tests\test_lora_combine_api.py
```

Result:

```text
17 passed in 1.09s
```

## Local note

There are old patch helper scripts still untracked in the local working tree, but they were not committed to this branch.