### PR TITLE
Phase 8.8d: display role recommendations in UI

### DIFF
--- a/Database/UI/src/App.jsx
+++ b/Database/UI/src/App.jsx
@@ -381,6 +381,34 @@ function canonicalizeWeightsPreview(blockList, n = 10) {
     .join(",");
 }
 
+function getRoleStrengthRecommendation(computed) {
+  const recommendation = computed?.role_strength_recommendation;
+  return recommendation && typeof recommendation === "object" ? recommendation : null;
+}
+
+function getRecommendedModelStrength(computed) {
+  const recommendation = getRoleStrengthRecommendation(computed);
+  const value = recommendation?.recommended_model_strength ?? computed?.strength_model ?? 1.0;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getRecommendedClipStrength(computed) {
+  const recommendation = getRoleStrengthRecommendation(computed);
+  if (recommendation && recommendation.recommended_clip_strength !== undefined) {
+    const value = recommendation.recommended_clip_strength;
+    if (value === null) return null;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : undefined;
+  }
+
+  const fallback = computed?.strength_clip;
+  if (fallback === null) return null;
+  if (fallback === undefined) return undefined;
+  const num = Number(fallback);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 function computeTameScale({ selectedItems, computedById, cap }) {
   // We tame by scaling strengths so that the *effective* per-block total influence
   // max_j Σ_i (strength_i * weight_i[j]) <= cap.
@@ -395,7 +423,7 @@ function computeTameScale({ selectedItems, computedById, cap }) {
     const blockList = getComputedBlockList(computed);
     if (!Array.isArray(blockList) || blockList.length === 0) continue;
 
-    const baseStrength = computed?.strength_model ?? 1.0;
+    const baseStrength = getRecommendedModelStrength(computed) ?? 1.0;
     const strength = Number(baseStrength);
     if (!Number.isFinite(strength) || strength <= 0) continue;
 
@@ -612,7 +640,8 @@ function CombineWorkbench(props) {
       const sid = it?.stable_id;
       if (!sid) continue;
       const computed = combineComputedById.get(sid) || null;
-      const base = computed?.strength_model ?? 1.0;
+      const base = getRecommendedModelStrength(computed);
+      if (base === null || base === undefined) continue;
       const baseNum = Number(base);
       if (!Number.isFinite(baseNum)) continue;
       m[sid] = baseNum * scale;
@@ -626,7 +655,7 @@ function CombineWorkbench(props) {
       const sid = it?.stable_id;
       if (!sid) continue;
       const computed = combineComputedById.get(sid) || null;
-      const base = computed?.strength_clip;
+      const base = getRecommendedClipStrength(computed);
       if (base === null) {
         m[sid] = null;
         continue;

--- a/Database/UI/src/App.smoke.test.jsx
+++ b/Database/UI/src/App.smoke.test.jsx
@@ -95,6 +95,12 @@ describe("App combine smoke", () => {
               block_layout: "flux_fallback_16",
               strength_model: 0.8,
               strength_clip: 1.0,
+              role_strength_recommendation: {
+                recommended_model_strength: 0.45,
+                recommended_clip_strength: 0.25,
+                applied_to_math: false,
+                basis: "role_policy_advisory",
+              },
               block_weights: [1.0, 0.9, 0.8],
               block_weights_csv: "1.0000,0.9000,0.8000",
               orchestration_notes: ["Phase 8.5 smoke note for sid-1"],
@@ -107,6 +113,12 @@ describe("App combine smoke", () => {
               block_layout: "flux_fallback_16",
               strength_model: 0.6,
               strength_clip: 0.9,
+              role_strength_recommendation: {
+                recommended_model_strength: 0.35,
+                recommended_clip_strength: 0.15,
+                applied_to_math: false,
+                basis: "role_policy_advisory",
+              },
               block_weights: [0.7, 0.6, 0.5],
               block_weights_csv: "0.7000,0.6000,0.5000",
               orchestration_notes: ["Phase 8.5 smoke note for sid-2"],
@@ -147,6 +159,8 @@ describe("App combine smoke", () => {
       const stack = within(selectedStack);
       expect(stack.getAllByText("sid-1").length).toBeGreaterThan(0);
       expect(stack.getAllByText("sid-2").length).toBeGreaterThan(0);
+      expect(stack.getByText(/0\.45/)).toBeTruthy();
+      expect(stack.getByText(/0\.25/)).toBeTruthy();
       expect(stack.getByText(/1\.0,0\.9,0\.8/i)).toBeTruthy();
       expect(stack.getByText(/0\.7,0\.6,0\.5/i)).toBeTruthy();
       expect(stack.getByText(/Stack Health/i)).toBeTruthy();


### PR DESCRIPTION
## Summary

Updates the Combine UI to prefer explicit backend role recommendation values for displayed recommended strengths.

## Changes

- Adds UI helpers for reading the role recommendation object safely.
- Recommended model strength now prefers the advisory recommendation value.
- Recommended clip strength now prefers the advisory recommendation value.
- Existing fallback behaviour remains intact when the recommendation object is missing.
- Updates the smoke test fixture and assertions.

## Testing

Verified locally on Bender:

```text
cd "E:\LoRA Project\Database\UI"
npm test -- --run
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

Note: phase88d_ui_patch.py is untracked locally and was intentionally not committed.