### PR TITLE
Phase 8.9: add read-only model ecosystem audit

### DIFF
--- a/Database/backend/phase89_audit.py
+++ b/Database/backend/phase89_audit.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import quote
+
+DEFAULT_LORA_ROOT = os.environ.get("LORA_ROOT", r"E:\models\loras")
+DEFAULT_DB_PATH = os.environ.get("LORA_DB_PATH", r"E:\LoRA Project\Database\lora_master.db")
+DEFAULT_IGNORED_FOLDERS = ("LoRA_Manager_Images", "recipes")
+
+
+def _normalise_separators(value: str) -> str:
+    value = str(value or "").strip().replace("\\", "/")
+    return re.sub(r"/+", "/", value)
+
+
+def _casefold_path(value: str) -> str:
+    return _normalise_separators(value).strip("/").casefold()
+
+
+def _path_parts(value: str) -> list[str]:
+    normalised = _normalise_separators(value)
+    return [part for part in normalised.split("/") if part not in ("", ".")]
+
+
+def _top_level_lookup(folder_names: Iterable[str]) -> dict[str, str]:
+    return {name.casefold(): name for name in folder_names}
+
+
+def canonical_db_relative_path(
+    file_path: str,
+    *,
+    root_dir: str,
+    top_level_folders: Sequence[str],
+) -> str | None:
+    """Map a DB path to a case-insensitive path relative to the mounted root.
+
+    Production DB rows may contain Windows paths while the live mount is POSIX.
+    First try to strip the configured root. If that cannot work because the DB
+    was created on a different host, anchor the path at a known top-level folder.
+    """
+    raw = _normalise_separators(file_path)
+    if not raw:
+        return None
+
+    root = _normalise_separators(root_dir).rstrip("/")
+    raw_fold = raw.casefold()
+    root_fold = root.casefold()
+    if raw_fold == root_fold:
+        return ""
+    if root and raw_fold.startswith(root_fold + "/"):
+        return _casefold_path(raw[len(root) + 1 :])
+
+    lookup = _top_level_lookup(top_level_folders)
+    parts = _path_parts(raw)
+    for index, part in enumerate(parts):
+        canonical_top = lookup.get(part.casefold())
+        if canonical_top is None:
+            continue
+        relative_parts = [canonical_top, *parts[index + 1 :]]
+        return _casefold_path("/".join(relative_parts))
+
+    return None
+
+
+def open_read_only_db(db_path: str | os.PathLike[str]) -> sqlite3.Connection:
+    resolved = Path(db_path).expanduser().resolve(strict=True)
+    uri_path = quote(resolved.as_posix(), safe="/:")
+    conn = sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON;")
+    return conn
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table});")}
+    except sqlite3.DatabaseError:
+        return set()
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def discover_library(
+    root_dir: str | os.PathLike[str],
+    ignored_folders: Iterable[str],
+) -> dict[str, Any]:
+    root = Path(root_dir).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise NotADirectoryError(f"LoRA root is not a directory: {root}")
+
+    ignored = {name.casefold() for name in ignored_folders}
+    top_level_folders: list[str] = []
+    ignored_present: list[str] = []
+    mounted_files: dict[str, str] = {}
+    top_level_file_counts: Counter[str] = Counter()
+    root_level_safetensors: list[str] = []
+
+    for child in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+        if child.is_dir():
+            if child.name.casefold() in ignored:
+                ignored_present.append(child.name)
+                continue
+            top_level_folders.append(child.name)
+        elif child.is_file() and child.suffix.casefold() == ".safetensors":
+            relative = child.relative_to(root).as_posix()
+            canonical = _casefold_path(relative)
+            mounted_files[canonical] = relative
+            root_level_safetensors.append(relative)
+            top_level_file_counts["(root)"] += 1
+
+    for folder_name in top_level_folders:
+        folder = root / folder_name
+        for dirpath, dirnames, filenames in os.walk(folder):
+            dirnames[:] = sorted(dirnames, key=str.casefold)
+            for filename in sorted(filenames, key=str.casefold):
+                if not filename.casefold().endswith(".safetensors"):
+                    continue
+                path = Path(dirpath) / filename
+                relative = path.relative_to(root).as_posix()
+                canonical = _casefold_path(relative)
+                mounted_files[canonical] = relative
+                top_level_file_counts[folder_name] += 1
+
+    return {
+        "root": str(root),
+        "top_level_folders": top_level_folders,
+        "ignored_folders_present": ignored_present,
+        "mounted_files": mounted_files,
+        "top_level_file_counts": dict(top_level_file_counts),
+        "root_level_safetensors": root_level_safetensors,
+    }
+
+
+def _load_block_counts(conn: sqlite3.Connection) -> dict[int, int]:
+    columns = _table_columns(conn, "lora_block_weights")
+    if "lora_id" not in columns:
+        return {}
+    return {
+        int(row["lora_id"]): int(row["block_count"] or 0)
+        for row in conn.execute(
+            """
+            SELECT lora_id, COUNT(1) AS block_count
+            FROM lora_block_weights
+            GROUP BY lora_id
+            """
+        )
+    }
+
+
+def _classification(row: Mapping[str, Any], block_count: int) -> str:
+    has_flag = bool(_safe_int(row.get("has_block_weights")))
+    layout = str(row.get("block_layout") or "").strip()
+    if block_count > 0 and has_flag:
+        return "scanned"
+    if has_flag and block_count == 0:
+        return "flagged_missing_blocks"
+    if block_count > 0 and not has_flag:
+        return "blocks_without_flag"
+    if layout:
+        return "fallback_only"
+    return "metadata_only"
+
+
+def _support_status(counts: Mapping[str, int], db_rows: int) -> str:
+    if db_rows == 0:
+        return "unindexed"
+    scanned = counts.get("scanned", 0)
+    fallback = counts.get("fallback_only", 0)
+    metadata = counts.get("metadata_only", 0)
+    inconsistent = counts.get("flagged_missing_blocks", 0) + counts.get("blocks_without_flag", 0)
+    if inconsistent:
+        return "inconsistent"
+    if scanned and scanned == db_rows:
+        return "scanned"
+    if scanned:
+        return "mixed"
+    if fallback and fallback == db_rows:
+        return "fallback-only"
+    if metadata and metadata == db_rows:
+        return "metadata-only"
+    if fallback or metadata:
+        return "mixed-unscanned"
+    return "unknown"
+
+
+def _display_list(values: Iterable[str], limit: int) -> dict[str, Any]:
+    ordered = sorted(values, key=str.casefold)
+    return {"count": len(ordered), "sample": ordered[:limit], "all": ordered}
+
+
+def run_audit(
+    *,
+    root_dir: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    ignored_folders: Iterable[str] = DEFAULT_IGNORED_FOLDERS,
+    sample_limit: int = 20,
+) -> dict[str, Any]:
+    library = discover_library(root_dir, ignored_folders)
+    ignored = {name.casefold() for name in ignored_folders}
+    comparison_folders = [*library["top_level_folders"], *library["ignored_folders_present"]]
+    mounted_files: dict[str, str] = library["mounted_files"]
+    mounted_set = set(mounted_files)
+
+    conn = open_read_only_db(db_path)
+    try:
+        lora_columns = _table_columns(conn, "lora")
+        required = {"id", "file_path"}
+        missing_required = sorted(required - lora_columns)
+        if missing_required:
+            raise RuntimeError(f"lora table is missing required column(s): {', '.join(missing_required)}")
+
+        select_columns = [
+            name
+            for name in (
+                "id",
+                "file_path",
+                "filename",
+                "base_model_name",
+                "base_model_code",
+                "stable_id",
+                "has_block_weights",
+                "block_layout",
+                "model_family",
+                "lora_type",
+            )
+            if name in lora_columns
+        ]
+        rows = [dict(row) for row in conn.execute(f"SELECT {', '.join(select_columns)} FROM lora ORDER BY id")]
+        block_counts = _load_block_counts(conn)
+    finally:
+        conn.close()
+
+    db_by_canonical: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    unresolved_db_rows: list[str] = []
+    ignored_db_rows: list[str] = []
+    group_counts: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    folder_stats: dict[str, dict[str, Any]] = {}
+    top_lookup = _top_level_lookup(library["top_level_folders"])
+
+    for folder in library["top_level_folders"]:
+        folder_stats[folder] = {
+            "folder": folder,
+            "mounted_files": _safe_int(library["top_level_file_counts"].get(folder)),
+            "db_rows": 0,
+            "with_stable_id": 0,
+            "without_stable_id": 0,
+            "classifications": Counter(),
+            "observed_base_model_names": set(),
+            "observed_base_model_codes": set(),
+            "stale_db_rows": 0,
+            "missing_from_db": 0,
+        }
+
+    overall_classifications: Counter[str] = Counter()
+    with_stable_id = 0
+
+    for row in rows:
+        row_id = _safe_int(row.get("id"))
+        block_count = block_counts.get(row_id, 0)
+        classification = _classification(row, block_count)
+        overall_classifications[classification] += 1
+        stable_id = str(row.get("stable_id") or "").strip()
+        if stable_id:
+            with_stable_id += 1
+
+        name = str(row.get("base_model_name") or "NULL")
+        code = str(row.get("base_model_code") or "NULL")
+        group_counts[(name, code)]["rows"] += 1
+        group_counts[(name, code)][classification] += 1
+        group_counts[(name, code)]["with_stable_id" if stable_id else "without_stable_id"] += 1
+
+        canonical = canonical_db_relative_path(
+            str(row.get("file_path") or ""),
+            root_dir=str(root_dir),
+            top_level_folders=comparison_folders,
+        )
+        if canonical is None:
+            unresolved_db_rows.append(str(row.get("file_path") or ""))
+            continue
+
+        top_part = canonical.split("/", 1)[0]
+        if top_part in ignored:
+            ignored_db_rows.append(str(row.get("file_path") or ""))
+            continue
+
+        db_by_canonical[canonical].append(row)
+        folder_name = top_lookup.get(top_part)
+        if folder_name is None:
+            continue
+        stats = folder_stats[folder_name]
+        stats["db_rows"] += 1
+        stats["with_stable_id" if stable_id else "without_stable_id"] += 1
+        stats["classifications"][classification] += 1
+        if row.get("base_model_name"):
+            stats["observed_base_model_names"].add(str(row["base_model_name"]))
+        if row.get("base_model_code"):
+            stats["observed_base_model_codes"].add(str(row["base_model_code"]))
+
+    db_set = set(db_by_canonical)
+    missing_from_db_keys = mounted_set - db_set
+    stale_db_keys = db_set - mounted_set
+    duplicate_db_keys = {key for key, matching_rows in db_by_canonical.items() if len(matching_rows) > 1}
+
+    for canonical in missing_from_db_keys:
+        top_part = canonical.split("/", 1)[0]
+        folder_name = top_lookup.get(top_part)
+        if folder_name:
+            folder_stats[folder_name]["missing_from_db"] += 1
+    for canonical in stale_db_keys:
+        top_part = canonical.split("/", 1)[0]
+        folder_name = top_lookup.get(top_part)
+        if folder_name:
+            folder_stats[folder_name]["stale_db_rows"] += len(db_by_canonical[canonical])
+
+    matrix: list[dict[str, Any]] = []
+    for folder in library["top_level_folders"]:
+        stats = folder_stats[folder]
+        classifications = dict(sorted(stats["classifications"].items()))
+        matrix.append(
+            {
+                "folder": folder,
+                "mounted_files": stats["mounted_files"],
+                "db_rows": stats["db_rows"],
+                "with_stable_id": stats["with_stable_id"],
+                "without_stable_id": stats["without_stable_id"],
+                "classifications": classifications,
+                "support_status": _support_status(classifications, stats["db_rows"]),
+                "observed_base_model_names": sorted(stats["observed_base_model_names"], key=str.casefold),
+                "observed_base_model_codes": sorted(stats["observed_base_model_codes"], key=str.casefold),
+                "stale_db_rows": stats["stale_db_rows"],
+                "missing_from_db": stats["missing_from_db"],
+            }
+        )
+
+    base_model_groups = []
+    for (name, code), counts in sorted(group_counts.items(), key=lambda item: (item[0][1], item[0][0])):
+        base_model_groups.append(
+            {
+                "base_model_name": name,
+                "base_model_code": code,
+                **dict(sorted(counts.items())),
+            }
+        )
+
+    missing_display = [mounted_files[key] for key in missing_from_db_keys]
+    stale_display = [db_by_canonical[key][0].get("file_path") or key for key in stale_db_keys]
+    duplicate_display = [
+        {
+            "canonical_path": key,
+            "db_row_ids": [_safe_int(row.get("id")) for row in db_by_canonical[key]],
+        }
+        for key in sorted(duplicate_db_keys)
+    ]
+
+    return {
+        "audit_mode": "read-only",
+        "comparison_mode": "canonical relative path (Windows/POSIX neutral)",
+        "root_dir": str(Path(root_dir).expanduser().resolve()),
+        "db_path": str(Path(db_path).expanduser().resolve()),
+        "ignored_folders": sorted(set(ignored_folders), key=str.casefold),
+        "top_level_folders": library["top_level_folders"],
+        "ignored_folders_present": library["ignored_folders_present"],
+        "summary": {
+            "mounted_safetensors": len(mounted_set),
+            "db_rows": len(rows),
+            "with_stable_id": with_stable_id,
+            "without_stable_id": len(rows) - with_stable_id,
+            "classifications": dict(sorted(overall_classifications.items())),
+            "stale_db_rows": sum(len(db_by_canonical[key]) for key in stale_db_keys),
+            "mounted_files_missing_from_db": len(missing_from_db_keys),
+            "unresolved_db_paths": len(unresolved_db_rows),
+            "ignored_db_rows": len(ignored_db_rows),
+            "duplicate_canonical_db_paths": len(duplicate_db_keys),
+        },
+        "base_model_groups": base_model_groups,
+        "support_matrix": matrix,
+        "stale_db_paths": _display_list(stale_display, sample_limit),
+        "mounted_files_missing_from_db": _display_list(missing_display, sample_limit),
+        "unresolved_db_paths": _display_list(unresolved_db_rows, sample_limit),
+        "ignored_db_paths": _display_list(ignored_db_rows, sample_limit),
+        "duplicate_canonical_db_paths": {
+            "count": len(duplicate_display),
+            "sample": duplicate_display[:sample_limit],
+            "all": duplicate_display,
+        },
+        "root_level_safetensors": library["root_level_safetensors"],
+    }
+
+
+def _print_matrix(report: Mapping[str, Any]) -> None:
+    print("\n=== Model ecosystem support matrix ===")
+    header = f"{'Folder':<22} {'Mounted':>7} {'DB':>7} {'IDs':>7} {'Scanned':>8} {'Fallback':>9} {'Metadata':>9} {'Missing':>8} {'Stale':>7}  Status"
+    print(header)
+    print("-" * len(header))
+    for row in report["support_matrix"]:
+        counts = row["classifications"]
+        print(
+            f"{row['folder']:<22} "
+            f"{row['mounted_files']:>7} "
+            f"{row['db_rows']:>7} "
+            f"{row['with_stable_id']:>7} "
+            f"{counts.get('scanned', 0):>8} "
+            f"{counts.get('fallback_only', 0):>9} "
+            f"{counts.get('metadata_only', 0):>9} "
+            f"{row['missing_from_db']:>8} "
+            f"{row['stale_db_rows']:>7}  "
+            f"{row['support_status']}"
+        )
+
+
+def print_report(report: Mapping[str, Any]) -> None:
+    summary = report["summary"]
+    print("=== Phase 8.9 read-only audit ===")
+    print(f"LoRA root : {report['root_dir']}")
+    print(f"Database  : {report['db_path']}")
+    print(f"Mode      : {report['audit_mode']}")
+    print(f"Compare   : {report['comparison_mode']}")
+    print()
+    print(f"Mounted .safetensors          : {summary['mounted_safetensors']}")
+    print(f"DB rows                      : {summary['db_rows']}")
+    print(f"With stable_id               : {summary['with_stable_id']}")
+    print(f"Without stable_id            : {summary['without_stable_id']}")
+    print(f"DB rows missing on mount     : {summary['stale_db_rows']}")
+    print(f"Mounted files missing in DB  : {summary['mounted_files_missing_from_db']}")
+    print(f"Unresolved DB paths          : {summary['unresolved_db_paths']}")
+    print(f"Ignored DB rows              : {summary['ignored_db_rows']}")
+    print(f"Duplicate canonical DB paths : {summary['duplicate_canonical_db_paths']}")
+    print("Classifications              : " + json.dumps(summary["classifications"], sort_keys=True))
+    _print_matrix(report)
+
+    for key, title in (
+        ("stale_db_paths", "DB rows whose mounted file no longer exists"),
+        ("mounted_files_missing_from_db", "Mounted files missing from DB"),
+        ("unresolved_db_paths", "DB paths that could not be matched to a mounted family"),
+    ):
+        section = report[key]
+        print(f"\n=== {title} ({section['count']}) ===")
+        for value in section["sample"]:
+            print(f"  {value}")
+        if section["count"] > len(section["sample"]):
+            print(f"  ... {section['count'] - len(section['sample'])} more in JSON output")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only Phase 8.9 audit of mounted LoRA files and the current SQLite index."
+    )
+    parser.add_argument("--root", default=DEFAULT_LORA_ROOT, help="Mounted LoRA library root")
+    parser.add_argument("--db", default=DEFAULT_DB_PATH, help="Current lora_master.db path")
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=None,
+        help="Top-level folder to ignore; repeat for multiple folders",
+    )
+    parser.add_argument("--json", dest="json_path", help="Optional path for the full JSON report")
+    parser.add_argument("--sample-limit", type=int, default=20, help="Console sample size per discrepancy list")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    ignored = args.ignore if args.ignore is not None else list(DEFAULT_IGNORED_FOLDERS)
+    report = run_audit(
+        root_dir=args.root,
+        db_path=args.db,
+        ignored_folders=ignored,
+        sample_limit=max(args.sample_limit, 0),
+    )
+    print_report(report)
+    if args.json_path:
+        output = Path(args.json_path).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"\nJSON report written to: {output.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Database/backend/phase89_relocation_audit.py
+++ b/Database/backend/phase89_relocation_audit.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from collections import Counter, defaultdict
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 DEFAULT_AUDIT_JSON = "/home/clink/docker/lora_builder/data/phase89_audit.json"
 

--- a/Database/backend/phase89_relocation_audit.py
+++ b/Database/backend/phase89_relocation_audit.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+DEFAULT_AUDIT_JSON = "/home/clink/docker/lora_builder/data/phase89_audit.json"
+
+
+def _normalise_path(value: Any) -> str:
+    return str(value or "").strip().replace("\\", "/")
+
+
+def _filename_key(path: Any) -> str:
+    return PurePosixPath(_normalise_path(path)).name.casefold()
+
+
+def _mounted_family(path: Any) -> str:
+    parts = [part for part in _normalise_path(path).split("/") if part]
+    return parts[0] if parts else "(root)"
+
+
+def _db_family(path: Any) -> str:
+    parts = [part for part in _normalise_path(path).split("/") if part]
+    for index, part in enumerate(parts):
+        if part.casefold() == "loras" and index + 1 < len(parts):
+            return parts[index + 1]
+    return "(unresolved)"
+
+
+def _as_all_paths(report: Mapping[str, Any], key: str) -> list[str]:
+    section = report.get(key) or {}
+    values = section.get("all") if isinstance(section, Mapping) else []
+    if not isinstance(values, list):
+        return []
+    return [str(value) for value in values]
+
+
+def analyse_relocations(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Compare stale DB paths with mounted files absent from the DB by filename.
+
+    This is deliberately conservative. A relocation candidate is only considered
+    unique when exactly one stale DB path and exactly one missing mounted path have
+    the same case-insensitive filename. File contents are never opened.
+    """
+    stale_paths = _as_all_paths(report, "stale_db_paths")
+    missing_paths = _as_all_paths(report, "mounted_files_missing_from_db")
+    unresolved_paths = _as_all_paths(report, "unresolved_db_paths")
+
+    stale_by_filename: dict[str, list[str]] = defaultdict(list)
+    missing_by_filename: dict[str, list[str]] = defaultdict(list)
+
+    for path in stale_paths:
+        stale_by_filename[_filename_key(path)].append(path)
+    for path in missing_paths:
+        missing_by_filename[_filename_key(path)].append(path)
+
+    unique_matches: list[dict[str, str]] = []
+    ambiguous_matches: list[dict[str, Any]] = []
+
+    shared_filenames = sorted(set(stale_by_filename) & set(missing_by_filename))
+    for filename_key in shared_filenames:
+        old_paths = sorted(stale_by_filename[filename_key], key=str.casefold)
+        new_paths = sorted(missing_by_filename[filename_key], key=str.casefold)
+        if len(old_paths) == 1 and len(new_paths) == 1:
+            old_path = old_paths[0]
+            new_path = new_paths[0]
+            unique_matches.append(
+                {
+                    "filename": PurePosixPath(_normalise_path(new_path)).name,
+                    "old_path": old_path,
+                    "new_path": new_path,
+                    "from_family": _db_family(old_path),
+                    "to_family": _mounted_family(new_path),
+                }
+            )
+        else:
+            ambiguous_matches.append(
+                {
+                    "filename": filename_key,
+                    "old_paths": old_paths,
+                    "new_paths": new_paths,
+                }
+            )
+
+    transition_counts = Counter(
+        (item["from_family"], item["to_family"]) for item in unique_matches
+    )
+    transitions = [
+        {"from_family": old, "to_family": new, "count": count}
+        for (old, new), count in sorted(
+            transition_counts.items(),
+            key=lambda item: (-item[1], item[0][0].casefold(), item[0][1].casefold()),
+        )
+    ]
+
+    legacy_counts = Counter(_db_family(path) for path in unresolved_paths)
+    legacy_families = [
+        {"family": family, "count": count}
+        for family, count in sorted(
+            legacy_counts.items(), key=lambda item: (-item[1], item[0].casefold())
+        )
+    ]
+
+    matched_old_paths = {item["old_path"] for item in unique_matches}
+    matched_new_paths = {item["new_path"] for item in unique_matches}
+
+    return {
+        "audit_mode": "read-only",
+        "matching_rule": "case-insensitive exact filename; one stale path to one missing mounted path",
+        "summary": {
+            "stale_current_family_rows": len(stale_paths),
+            "mounted_files_missing_from_db": len(missing_paths),
+            "unique_filename_matches": len(unique_matches),
+            "ambiguous_filename_matches": len(ambiguous_matches),
+            "unmatched_stale_rows": len(stale_paths) - len(matched_old_paths),
+            "unmatched_missing_files": len(missing_paths) - len(matched_new_paths),
+            "legacy_unmounted_rows": len(unresolved_paths),
+        },
+        "transitions": transitions,
+        "unique_matches": unique_matches,
+        "ambiguous_matches": ambiguous_matches,
+        "legacy_families": legacy_families,
+    }
+
+
+def print_report(report: Mapping[str, Any], sample_limit: int = 30) -> None:
+    summary = report["summary"]
+    print("=== Phase 8.9 relocation audit ===")
+    print(f"Mode                         : {report['audit_mode']}")
+    print(f"Matching rule                : {report['matching_rule']}")
+    print(f"Stale current-family DB rows : {summary['stale_current_family_rows']}")
+    print(f"Mounted files missing in DB  : {summary['mounted_files_missing_from_db']}")
+    print(f"Unique filename matches      : {summary['unique_filename_matches']}")
+    print(f"Ambiguous filename matches   : {summary['ambiguous_filename_matches']}")
+    print(f"Unmatched stale DB rows      : {summary['unmatched_stale_rows']}")
+    print(f"Unmatched mounted files      : {summary['unmatched_missing_files']}")
+    print(f"Legacy/unmounted DB rows     : {summary['legacy_unmounted_rows']}")
+
+    print("\n=== Likely family/folder transitions ===")
+    for item in report["transitions"]:
+        print(f"{item['count']:4}  {item['from_family']} -> {item['to_family']}")
+
+    print("\n=== Sample unique relocation candidates ===")
+    for item in report["unique_matches"][: max(sample_limit, 0)]:
+        print(f"OLD: {item['old_path']}")
+        print(f"NEW: {item['new_path']}")
+        print()
+
+    print("=== Legacy/unmounted DB families ===")
+    for item in report["legacy_families"]:
+        print(f"{item['count']:4}  {item['family']}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only exact-filename relocation analysis for a Phase 8.9 audit JSON report."
+    )
+    parser.add_argument(
+        "--audit-json",
+        default=DEFAULT_AUDIT_JSON,
+        help="JSON produced by phase89_audit.py",
+    )
+    parser.add_argument("--json", dest="json_path", help="Optional output path for relocation JSON")
+    parser.add_argument("--sample-limit", type=int, default=30, help="Console relocation sample size")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    source = Path(args.audit_json).expanduser().resolve(strict=True)
+    audit_report = json.loads(source.read_text(encoding="utf-8"))
+    report = analyse_relocations(audit_report)
+    print_report(report, sample_limit=args.sample_limit)
+
+    if args.json_path:
+        output = Path(args.json_path).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"\nJSON report written to: {output.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Database/backend/tests/test_phase89_audit.py
+++ b/Database/backend/tests/test_phase89_audit.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from phase89_audit import open_read_only_db, run_audit
+
+
+def _create_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY,
+            file_path TEXT NOT NULL,
+            filename TEXT,
+            base_model_name TEXT,
+            base_model_code TEXT,
+            stable_id TEXT,
+            has_block_weights INTEGER NOT NULL DEFAULT 0,
+            block_layout TEXT,
+            model_family TEXT,
+            lora_type TEXT
+        );
+        CREATE TABLE lora_block_weights (
+            id INTEGER PRIMARY KEY,
+            lora_id INTEGER NOT NULL,
+            block_index INTEGER NOT NULL,
+            weight REAL NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"test")
+
+
+def test_audit_matches_windows_db_paths_to_posix_mount(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+
+    _touch(root / "FLUX" / "01 - People" / "one.safetensors")
+    _touch(root / "SDXL" / "02 - Styles" / "two.safetensors")
+    _touch(root / "Z-Image" / "03 - Utils" / "new.safetensors")
+    _touch(root / "recipes" / "ignored.safetensors")
+    _touch(root / "LoRA_Manager_Images" / "ignored-image.safetensors")
+
+    _create_db(db)
+    conn = sqlite3.connect(db)
+    conn.executemany(
+        """
+        INSERT INTO lora (
+            id, file_path, filename, base_model_name, base_model_code,
+            stable_id, has_block_weights, block_layout
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (1, r"E:\models\loras\FLUX\01 - People\one.safetensors", "one.safetensors", "Flux", "FLX", "FLX-PPL-001", 1, "flux_transformer_38"),
+            (2, r"E:\models\loras\SDXL\02 - Styles\two.safetensors", "two.safetensors", "SDXL", "SDX", None, 0, None),
+            (3, r"E:\models\loras\SDXL\02 - Styles\deleted.safetensors", "deleted.safetensors", "SDXL", "SDX", "SDX-STL-001", 0, None),
+            (4, r"E:\models\loras\LoRA_Manager_Images\ignored-image.safetensors", "ignored-image.safetensors", None, None, None, 0, None),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO lora_block_weights (lora_id, block_index, weight) VALUES (1, 0, 1.0)"
+    )
+    conn.commit()
+    conn.close()
+
+    report = run_audit(root_dir=root, db_path=db)
+
+    assert report["audit_mode"] == "read-only"
+    assert report["top_level_folders"] == ["FLUX", "SDXL", "Z-Image"]
+    assert report["summary"]["mounted_safetensors"] == 3
+    assert report["summary"]["db_rows"] == 4
+    assert report["summary"]["with_stable_id"] == 2
+    assert report["summary"]["without_stable_id"] == 2
+    assert report["summary"]["stale_db_rows"] == 1
+    assert report["summary"]["mounted_files_missing_from_db"] == 1
+    assert report["summary"]["ignored_db_rows"] == 1
+
+    matrix = {row["folder"]: row for row in report["support_matrix"]}
+    assert matrix["FLUX"]["support_status"] == "scanned"
+    assert matrix["FLUX"]["classifications"] == {"scanned": 1}
+    assert matrix["SDXL"]["support_status"] == "metadata-only"
+    assert matrix["SDXL"]["stale_db_rows"] == 1
+    assert matrix["Z-Image"]["support_status"] == "unindexed"
+    assert matrix["Z-Image"]["missing_from_db"] == 1
+    assert report["mounted_files_missing_from_db"]["all"] == ["Z-Image/03 - Utils/new.safetensors"]
+    assert report["stale_db_paths"]["count"] == 1
+    json.dumps(report)
+
+
+def test_open_read_only_db_rejects_writes(tmp_path: Path) -> None:
+    db = tmp_path / "read_only.db"
+    _create_db(db)
+
+    conn = open_read_only_db(db)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO lora (id, file_path) VALUES (1, 'x')")
+    finally:
+        conn.close()
+
+
+def test_flag_and_block_row_inconsistencies_are_explicit(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+    _touch(root / "FLUX" / "03 - Utils" / "flag-only.safetensors")
+    _touch(root / "FLUX" / "03 - Utils" / "rows-only.safetensors")
+    _create_db(db)
+
+    conn = sqlite3.connect(db)
+    conn.executemany(
+        """
+        INSERT INTO lora (id, file_path, filename, base_model_name, base_model_code, stable_id, has_block_weights, block_layout)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (1, r"E:\models\loras\FLUX\03 - Utils\flag-only.safetensors", "flag-only.safetensors", "Flux", "FLX", "FLX-UTL-001", 1, "flux_transformer_38"),
+            (2, r"E:\models\loras\FLUX\03 - Utils\rows-only.safetensors", "rows-only.safetensors", "Flux", "FLX", "FLX-UTL-002", 0, "flux_transformer_38"),
+        ],
+    )
+    conn.execute("INSERT INTO lora_block_weights (lora_id, block_index, weight) VALUES (2, 0, 0.5)")
+    conn.commit()
+    conn.close()
+
+    report = run_audit(root_dir=root, db_path=db)
+    assert report["summary"]["classifications"] == {
+        "blocks_without_flag": 1,
+        "flagged_missing_blocks": 1,
+    }
+    assert report["support_matrix"][0]["support_status"] == "inconsistent"

--- a/Database/backend/tests/test_phase89_audit.py
+++ b/Database/backend/tests/test_phase89_audit.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from phase89_audit import open_read_only_db, run_audit
 

--- a/Database/backend/tests/test_phase89_relocation_audit.py
+++ b/Database/backend/tests/test_phase89_relocation_audit.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from phase89_relocation_audit import analyse_relocations
 
 

--- a/Database/backend/tests/test_phase89_relocation_audit.py
+++ b/Database/backend/tests/test_phase89_relocation_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from phase89_relocation_audit import analyse_relocations
+
+
+def _section(values):
+    return {"count": len(values), "sample": values[:20], "all": values}
+
+
+def test_unique_and_ambiguous_filename_matches_are_separated() -> None:
+    report = {
+        "stale_db_paths": _section(
+            [
+                "/loras/WAN2.2/T2V/04 - Action/moved.safetensors",
+                "/loras/FLUX/01 - People/duplicate.safetensors",
+                "/loras/FLUX/02 - Styles/duplicate.safetensors",
+                "/loras/FLUX/03 - Utils/deleted.safetensors",
+            ]
+        ),
+        "mounted_files_missing_from_db": _section(
+            [
+                "WAN2.1/T2V/04 - Action/moved.safetensors",
+                "Z-Image/03 - Utils/duplicate.safetensors",
+                "LTXV2/03 - Utils/new.safetensors",
+            ]
+        ),
+        "unresolved_db_paths": _section(
+            [
+                "/loras/Hunyuna_15/03 - Utils/old-one.safetensors",
+                "/loras/Hunyuna_15/04 - Action/old-two.safetensors",
+                "/loras/SD/02 - Styles/old-three.safetensors",
+            ]
+        ),
+    }
+
+    result = analyse_relocations(report)
+
+    assert result["audit_mode"] == "read-only"
+    assert result["summary"] == {
+        "stale_current_family_rows": 4,
+        "mounted_files_missing_from_db": 3,
+        "unique_filename_matches": 1,
+        "ambiguous_filename_matches": 1,
+        "unmatched_stale_rows": 3,
+        "unmatched_missing_files": 2,
+        "legacy_unmounted_rows": 3,
+    }
+    assert result["unique_matches"] == [
+        {
+            "filename": "moved.safetensors",
+            "old_path": "/loras/WAN2.2/T2V/04 - Action/moved.safetensors",
+            "new_path": "WAN2.1/T2V/04 - Action/moved.safetensors",
+            "from_family": "WAN2.2",
+            "to_family": "WAN2.1",
+        }
+    ]
+    assert result["ambiguous_matches"][0]["filename"] == "duplicate.safetensors"
+    assert result["transitions"] == [
+        {"from_family": "WAN2.2", "to_family": "WAN2.1", "count": 1}
+    ]
+    assert result["legacy_families"] == [
+        {"family": "Hunyuna_15", "count": 2},
+        {"family": "SD", "count": 1},
+    ]
+
+
+def test_filename_matching_is_case_insensitive() -> None:
+    report = {
+        "stale_db_paths": _section([r"E:\models\loras\Z-Image\04 - Action\Example.SAFETENSORS"]),
+        "mounted_files_missing_from_db": _section(["Z-Image/05 - Body/example.safetensors"]),
+        "unresolved_db_paths": _section([]),
+    }
+
+    result = analyse_relocations(report)
+
+    assert result["summary"]["unique_filename_matches"] == 1
+    assert result["unique_matches"][0]["from_family"] == "Z-Image"
+    assert result["unique_matches"][0]["to_family"] == "Z-Image"

--- a/docs/phase89-read-only-audit.md
+++ b/docs/phase89-read-only-audit.md
@@ -43,11 +43,42 @@ The console shows the summary and matrix. The full discrepancy lists are written
 
 This command does not call `/api/lora/reindex_all`, `lora_indexer.py`, or any reindex endpoint.
 
+## Follow-up relocation audit
+
+The companion `phase89_relocation_audit.py` consumes the main JSON report and conservatively reports:
+
+- one-to-one exact-filename relocation candidates;
+- ambiguous filename matches;
+- family/folder transitions;
+- legacy or currently unmounted DB families.
+
+Run without changing the live checkout:
+
+```bash
+cd /home/clink/docker/lora_builder/app/LoRA_weights_builder
+git fetch origin agent/phase89-read-only-audit
+git show FETCH_HEAD:Database/backend/phase89_relocation_audit.py \
+  | sudo tee /tmp/phase89_relocation_audit.py >/dev/null
+sudo python3 /tmp/phase89_relocation_audit.py \
+  --audit-json /home/clink/docker/lora_builder/data/phase89_audit.json \
+  --json /home/clink/docker/lora_builder/data/phase89_relocation_audit.json
+```
+
+This remains read-only. An exact-filename candidate is not proof that the file content is identical, so it must not update a path or stable ID automatically.
+
 ## Run tests on Bender
 
 From **Bender / VS Code PowerShell**:
 
 ```powershell
 cd 'E:\LoRA Project'
-python -m pytest Database\backend\tests\test_phase89_audit.py -q
+python -m pytest Database\backend\tests\test_phase89_audit.py Database\backend\tests\test_phase89_relocation_audit.py -q
 ```
+
+## Reconciliation guardrails
+
+- Do not run an uncontrolled full rescan.
+- Do not delete stale rows automatically.
+- Preserve stable IDs for confirmed moves.
+- Require a DB backup and a reviewed dry-run plan before any write-capable reconciliation.
+- Use stronger identity evidence, such as file size or hash, before applying relocation updates.

--- a/docs/phase89-read-only-audit.md
+++ b/docs/phase89-read-only-audit.md
@@ -1,0 +1,53 @@
+# Phase 8.9 read-only model ecosystem audit
+
+This audit compares the mounted LoRA library with the current SQLite index without invoking the indexer, opening safetensors tensors, changing schema, or writing to the database.
+
+It reports:
+
+- top-level mounted folders and `.safetensors` counts
+- DB rows by `base_model_name` and `base_model_code`
+- `stable_id` coverage
+- scanned, fallback-only, metadata-only, and inconsistent block-weight rows
+- DB paths whose mounted file is no longer present
+- mounted files missing from the DB
+- duplicate or unresolvable DB paths
+- a per-folder support matrix
+
+`LoRA_Manager_Images` and `recipes` are ignored by default.
+
+## Safety properties
+
+- SQLite is opened with `mode=ro` and `PRAGMA query_only=ON`.
+- The script never imports or calls `lora_indexer`.
+- The LoRA mount remains read-only.
+- File comparison uses canonical paths relative to the library root, so Windows DB paths such as `E:\models\loras\...` can be compared with Nibbler paths under `/loras/...`.
+
+## Run on Nibbler
+
+After pulling the branch and rebuilding the backend image, run inside the backend container:
+
+```bash
+cd /home/clink/docker/lora_builder/app/LoRA_weights_builder/deploy/nibbler
+sudo docker compose --env-file .env exec -T backend \
+  python phase89_audit.py \
+  --root /loras \
+  --db /data/lora_master.db \
+  --json /data/phase89_audit.json
+```
+
+The console shows the summary and matrix. The full discrepancy lists are written to:
+
+```text
+/home/clink/docker/lora_builder/data/phase89_audit.json
+```
+
+This command does not call `/api/lora/reindex_all`, `lora_indexer.py`, or any reindex endpoint.
+
+## Run tests on Bender
+
+From **Bender / VS Code PowerShell**:
+
+```powershell
+cd 'E:\LoRA Project'
+python -m pytest Database\backend\tests\test_phase89_audit.py -q
+```

--- a/docs/phase89-relocation-audit.md
+++ b/docs/phase89-relocation-audit.md
@@ -1,0 +1,60 @@
+# Phase 8.9 relocation audit
+
+The first live Phase 8.9 audit showed that the current SQLite index contains both stale rows and mounted files that are not indexed.
+
+A normal indexer run is not a safe reconciliation mechanism because the current indexer inserts and updates discovered files but does not remove rows whose files are absent. It can also create a new row and stable ID for a file that was merely moved.
+
+## Read-only relocation analysis
+
+`phase89_relocation_audit.py` consumes the full JSON output from `phase89_audit.py` and compares:
+
+- current-family DB paths whose file is absent from the mount;
+- mounted files absent from the DB;
+- legacy DB paths whose top-level family no longer exists on the mount.
+
+It only declares a unique relocation candidate when exactly one stale path and exactly one missing mounted path share the same case-insensitive filename. It does not inspect safetensors content and does not write to SQLite.
+
+Run on Nibbler:
+
+```bash
+python3 /tmp/phase89_relocation_audit.py \
+  --audit-json /home/clink/docker/lora_builder/data/phase89_audit.json \
+  --json /home/clink/docker/lora_builder/data/phase89_relocation_audit.json
+```
+
+## First live result, 26 July 2026
+
+- Stale rows within currently mounted families: 691
+- Mounted files absent from the DB: 334
+- Unique exact-filename relocation candidates: 23
+- Ambiguous exact-filename candidates: 0
+- Legacy/unmounted-family DB rows: 114
+
+Observed relocation transitions:
+
+- 20 from WAN2.2 to WAN2.1
+- 2 within WAN2.2, from Action to Body
+- 1 within Z-Image, from Action to Body
+
+Legacy/unmounted DB families:
+
+- Hunyuna_15: 72
+- SD: 38
+- Wan Video 2.2 T2V-A14B: 2
+- Flux.1 D: 1
+- SDXL-Lightning: 1
+
+## Safety conclusion
+
+Do not run an uncontrolled full rescan or delete stale rows yet.
+
+The 23 unique filename matches are candidates for a future stable-ID-preserving path migration, not automatic proof that the files are identical. A write-capable reconciliation phase must include:
+
+1. database backup;
+2. dry-run plan;
+3. stable-ID collision checks;
+4. optional stronger identity checks such as file size or hash;
+5. explicit approval before applying updates or deletions;
+6. a post-change read-only audit.
+
+The remaining unmatched rows and files require separate review or controlled indexing after model-family mappings are defined.


### PR DESCRIPTION
## What changed

- Added `Database/backend/phase89_audit.py`, a standalone read-only audit of the mounted LoRA library and current SQLite index.
- Added canonical Windows/POSIX relative-path matching so legacy `E:\models\loras\...` rows compare correctly with Nibbler's `/loras/...` mount.
- Added a per-folder support matrix covering mounted files, DB rows, stable IDs, scanned/fallback/metadata classifications, stale rows, and unindexed files.
- Added explicit inconsistency reporting for block-weight flags versus actual `lora_block_weights` rows.
- Added `phase89_relocation_audit.py`, a second read-only pass that identifies conservative one-to-one exact-filename relocation candidates and legacy/unmounted families.
- Ignored `LoRA_Manager_Images` and `recipes` by default.
- Added focused tests and Nibbler runbooks.
- Made both Phase 8.9 test modules runnable from the repository root by resolving `Database/backend` explicitly.

## Safety

- Opens SQLite with `mode=ro` and `PRAGMA query_only=ON`.
- Does not import or invoke `lora_indexer`.
- Does not open safetensors tensors.
- Does not change DB schema, scanner maths, stable IDs, paths, or trigger a rescan.
- Relocation matches are advisory candidates only; they do not write to the DB.

## Validation

Verified on Bender from the repository root using the Miniconda Python environment:

```text
5 passed in 0.11s
```

The companion scripts also pass `python -m py_compile`.

## First live audit, 26 July 2026

- Mounted files: 2,053
- DB rows: 2,524
- Stale rows in currently mounted families: 691
- Mounted files absent from DB: 334
- Legacy/unmounted-family rows: 114
- Unique exact-filename relocation candidates: 23
- Ambiguous exact-filename candidates: 0

Observed relocation transitions:

- 20 WAN2.2 -> WAN2.1
- 2 within WAN2.2, Action -> Body
- 1 within Z-Image, Action -> Body

## Conclusion

Do not run an uncontrolled full rescan or delete stale rows yet. The next write-capable reconciliation phase must use a DB backup, dry-run plan, stable-ID collision checks, stronger identity evidence such as size/hash, explicit approval, and a post-change audit.