### PR TITLE
Phase 8.9a: add canonical model-family registry

### DIFF
--- a/Database/backend/lora_api_server_docker.py
+++ b/Database/backend/lora_api_server_docker.py
@@ -31,9 +31,11 @@ _schema_conn = lora_indexer.ensure_db()
 _schema_conn.close()
 
 import lora_api_server  # noqa: E402
+from model_family_router import router as model_family_router  # noqa: E402
 
 # Patch API DB path after import because lora_api_server has its own module-level
 # default. The startup backfill and all request handlers then use the mounted DB.
 lora_api_server.DB_PATH = _db_path
+lora_api_server.app.include_router(model_family_router)
 
 app = lora_api_server.app

--- a/Database/backend/model_family_registry.py
+++ b/Database/backend/model_family_registry.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Iterable, Literal
+
+SupportLevel = Literal[
+    "mixed-scanned-fallback",
+    "metadata-only",
+]
+
+
+@dataclass(frozen=True)
+class ModelFamilyDefinition:
+    folder_name: str
+    code: str
+    display_name: str
+    support_level: SupportLevel
+    metadata_indexing: bool
+    block_analysis: bool
+    fallback_layout: bool
+    role_aware_orchestration: bool
+    architecture_key_normalisation: bool
+    comfyui_export: bool
+    notes: str
+
+
+MODEL_FAMILIES: tuple[ModelFamilyDefinition, ...] = (
+    ModelFamilyDefinition(
+        folder_name="FLUX",
+        code="FLX",
+        display_name="Flux",
+        support_level="mixed-scanned-fallback",
+        metadata_indexing=True,
+        block_analysis=True,
+        fallback_layout=True,
+        role_aware_orchestration=True,
+        architecture_key_normalisation=True,
+        comfyui_export=True,
+        notes="Flux scanner is implemented; individual rows may still be scanned or fallback-only.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="Flux Krea",
+        code="FLK",
+        display_name="Flux Krea",
+        support_level="mixed-scanned-fallback",
+        metadata_indexing=True,
+        block_analysis=True,
+        fallback_layout=True,
+        role_aware_orchestration=True,
+        architecture_key_normalisation=True,
+        comfyui_export=True,
+        notes="Uses the current Flux scanner path; individual rows may still be scanned or fallback-only.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="Flux.2-Klein",
+        code="F2K",
+        display_name="Flux.2-Klein",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Known mounted family. Metadata support only until architecture-specific scanner and layout tests exist.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="Illustrious",
+        code="ILL",
+        display_name="Illustrious",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Metadata-only in the current indexer.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="LTXV2",
+        code="LTX",
+        display_name="LTXV2",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Known mounted family. Metadata support only until architecture-specific scanner and layout tests exist.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="PONY",
+        code="PNY",
+        display_name="Pony",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Metadata-only in the current indexer.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="SD",
+        code="SD1",
+        display_name="SD 1.x",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Legacy mapped family; not present in the current mounted top-level folder audit.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="SDXL",
+        code="SDX",
+        display_name="SDXL",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Metadata-only in the current indexer.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="WAN2.1",
+        code="W21",
+        display_name="WAN 2.1",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Mode-aware folder parsing exists; block extraction is not implemented.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="WAN2.2",
+        code="W22",
+        display_name="WAN 2.2",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Mode-aware folder parsing exists; block extraction is not implemented.",
+    ),
+    ModelFamilyDefinition(
+        folder_name="Z-Image",
+        code="ZIM",
+        display_name="Z-Image",
+        support_level="metadata-only",
+        metadata_indexing=True,
+        block_analysis=False,
+        fallback_layout=False,
+        role_aware_orchestration=False,
+        architecture_key_normalisation=False,
+        comfyui_export=False,
+        notes="Known mounted family. Metadata support only until architecture-specific scanner and layout tests exist.",
+    ),
+)
+
+
+def iter_model_families() -> Iterable[ModelFamilyDefinition]:
+    return MODEL_FAMILIES
+
+
+def get_model_family_by_folder(folder_name: str) -> ModelFamilyDefinition | None:
+    key = str(folder_name or "").strip().casefold()
+    return next((family for family in MODEL_FAMILIES if family.folder_name.casefold() == key), None)
+
+
+def get_model_family_by_code(code: str) -> ModelFamilyDefinition | None:
+    key = str(code or "").strip().upper()
+    return next((family for family in MODEL_FAMILIES if family.code == key), None)
+
+
+def base_model_map() -> dict[str, tuple[str, str]]:
+    """Return the folder mapping shape expected by the existing indexer."""
+    return {
+        family.folder_name: (family.code, family.display_name)
+        for family in MODEL_FAMILIES
+        if family.metadata_indexing
+    }
+
+
+def api_model_families() -> list[dict[str, object]]:
+    return [asdict(family) for family in MODEL_FAMILIES]

--- a/Database/backend/model_family_router.py
+++ b/Database/backend/model_family_router.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from model_family_registry import api_model_families
+
+router = APIRouter(prefix="/api", tags=["model-families"])
+
+
+@router.get("/model-families")
+def api_model_family_registry() -> dict[str, object]:
+    return {
+        "schema_version": "8.9a",
+        "families": api_model_families(),
+    }

--- a/Database/backend/requirements-test.txt
+++ b/Database/backend/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest>=8,<10
+httpx>=0.27,<1

--- a/Database/backend/tests/test_model_family_registry.py
+++ b/Database/backend/tests/test_model_family_registry.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from model_family_registry import (  # noqa: E402
+    MODEL_FAMILIES,
+    base_model_map,
+    get_model_family_by_code,
+    get_model_family_by_folder,
+)
+from model_family_router import router  # noqa: E402
+
+
+def test_registry_contains_full_known_library_ecosystem() -> None:
+    assert {family.folder_name for family in MODEL_FAMILIES} == {
+        "FLUX",
+        "Flux Krea",
+        "Flux.2-Klein",
+        "Illustrious",
+        "LTXV2",
+        "PONY",
+        "SD",
+        "SDXL",
+        "WAN2.1",
+        "WAN2.2",
+        "Z-Image",
+    }
+
+
+def test_codes_are_unique_three_character_identifiers() -> None:
+    codes = [family.code for family in MODEL_FAMILIES]
+    assert len(codes) == len(set(codes))
+    assert all(len(code) == 3 and code.isalnum() and code == code.upper() for code in codes)
+    assert get_model_family_by_folder("flux.2-klein").code == "F2K"
+    assert get_model_family_by_code("ltx").folder_name == "LTXV2"
+    assert get_model_family_by_code("zim").folder_name == "Z-Image"
+
+
+def test_only_flux_families_claim_block_analysis() -> None:
+    block_capable = {family.code for family in MODEL_FAMILIES if family.block_analysis}
+    assert block_capable == {"FLX", "FLK"}
+
+    for family in MODEL_FAMILIES:
+        if family.code not in block_capable:
+            assert family.support_level == "metadata-only"
+            assert family.role_aware_orchestration is False
+            assert family.architecture_key_normalisation is False
+            assert family.comfyui_export is False
+
+
+def test_base_model_map_matches_existing_indexer_shape() -> None:
+    mapping = base_model_map()
+    assert mapping["FLUX"] == ("FLX", "Flux")
+    assert mapping["Flux.2-Klein"] == ("F2K", "Flux.2-Klein")
+    assert mapping["LTXV2"] == ("LTX", "LTXV2")
+    assert mapping["Z-Image"] == ("ZIM", "Z-Image")
+
+
+def test_api_endpoint_exposes_explicit_support_capabilities() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/api/model-families")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_version"] == "8.9a"
+
+    by_code = {family["code"]: family for family in body["families"]}
+    assert by_code["FLX"]["block_analysis"] is True
+    assert by_code["F2K"]["support_level"] == "metadata-only"
+    assert by_code["LTX"]["block_analysis"] is False
+    assert by_code["ZIM"]["comfyui_export"] is False

--- a/docs/phase89a-model-family-registry.md
+++ b/docs/phase89a-model-family-registry.md
@@ -1,0 +1,58 @@
+# Phase 8.9a model-family registry
+
+This slice establishes a canonical, explicit registry for the LoRA model families known to the project.
+
+It does not run an index, modify the database, assign stable IDs, inspect safetensors files, or change scanner mathematics.
+
+## Registered families and codes
+
+| Folder | Code | Display name | Declared capability |
+|---|---:|---|---|
+| FLUX | FLX | Flux | Mixed scanned / fallback |
+| Flux Krea | FLK | Flux Krea | Mixed scanned / fallback |
+| Flux.2-Klein | F2K | Flux.2-Klein | Metadata only |
+| Illustrious | ILL | Illustrious | Metadata only |
+| LTXV2 | LTX | LTXV2 | Metadata only |
+| PONY | PNY | Pony | Metadata only |
+| SD | SD1 | SD 1.x | Metadata only / legacy mapped family |
+| SDXL | SDX | SDXL | Metadata only |
+| WAN2.1 | W21 | WAN 2.1 | Metadata only |
+| WAN2.2 | W22 | WAN 2.2 | Metadata only |
+| Z-Image | ZIM | Z-Image | Metadata only |
+
+All model codes remain three characters to preserve the existing stable-ID format.
+
+## Capability policy
+
+Only `FLX` and `FLK` currently claim:
+
+- block analysis
+- fallback layout support
+- architecture-specific key normalisation
+- role-aware orchestration for scanned rows
+- ComfyUI per-LoRA block payload export
+
+Every other family is explicitly declared metadata-only until scanner, layout, export, and architecture-specific tests exist.
+
+## API
+
+The Nibbler Docker application exposes:
+
+```text
+GET /api/model-families
+```
+
+The response includes the registry schema version and explicit capabilities for each family. This endpoint is intended to become the UI dropdown source in a later Phase 8.9 slice.
+
+## Safety
+
+This branch deliberately does not:
+
+- import the registry into `lora_indexer.py`
+- update existing DB rows
+- assign new stable IDs
+- add block layouts
+- run a full or partial rescan
+- change block extraction or orchestration maths
+
+The next integration step should replace duplicated family maps in the indexer/catalog and then update the UI to consume the API endpoint. Those changes should be reviewed before any controlled indexing operation.


### PR DESCRIPTION
## What changed

- Added a canonical backend model-family registry covering the complete known ecosystem.
- Added explicit three-character codes for the currently unmapped families:
  - `F2K` = Flux.2-Klein
  - `LTX` = LTXV2
  - `ZIM` = Z-Image
- Declared capability truth per family instead of implying support from folder presence.
- Added a read-only `GET /api/model-families` endpoint to the Nibbler Docker app.
- Added focused registry and endpoint tests.
- Added `Database/backend/requirements-test.txt` so backend test dependencies are reproducible on Bender.
- Added Phase 8.9a design/safety documentation.

## Capability policy

Only `FLX` and `FLK` claim block analysis, fallback layouts, architecture-specific key normalisation, role-aware orchestration for scanned rows, and ComfyUI per-LoRA block payload export.

All other families are explicitly metadata-only until architecture-specific scanner, layout, export, and test coverage exists.

## Safety

- No DB schema changes.
- No DB row changes.
- No stable-ID assignment.
- No full or partial rescan.
- No scanner maths changes.
- No block-layout changes.
- The registry is not yet imported by `lora_indexer.py`; this PR establishes the reviewed source of truth first.
- The current UI dropdown is not changed in this slice. A later slice can consume `/api/model-families` after this contract is approved.

## Validation

Verified on Bender from the repository root:

```text
5 passed in 0.52s
```
