### PR TITLE
Phase 8.9b: integrate registry with indexer metadata parsing

### DIFF
--- a/Database/backend/lora_api_server_docker.py
+++ b/Database/backend/lora_api_server_docker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import lora_id_assigner
 import lora_indexer
+from model_family_integration import apply_model_family_registry
 
 
 def _path_from_env(name: str, default: str) -> str:
@@ -17,6 +18,10 @@ def _path_from_env(name: str, default: str) -> str:
 # deployment use mounted Linux paths.
 RUNTIME_LORA_ROOT = _path_from_env("LORA_ROOT", "/loras")
 RUNTIME_DB_PATH = _path_from_env("LORA_DB_PATH", "/data/lora_master.db")
+
+# Apply the reviewed Phase 8.9 family metadata mapping before importing the API.
+# This changes folder parsing only; it does not run an index or alter scanner maths.
+apply_model_family_registry(lora_indexer)
 
 # Patch module-level script constants before importing the FastAPI app.
 lora_indexer.LORA_ROOT = RUNTIME_LORA_ROOT

--- a/Database/backend/lora_indexer_registered.py
+++ b/Database/backend/lora_indexer_registered.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import lora_indexer
+from model_family_integration import apply_model_family_registry
+
+
+def main() -> None:
+    apply_model_family_registry(lora_indexer)
+    lora_indexer.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/lora_path_parser.py
+++ b/Database/backend/lora_path_parser.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+from model_family_registry import base_model_map
+
+BASE_MODEL_MAP = base_model_map()
+
+CATEGORY_INDEX_MAP: dict[str, tuple[str, str]] = {
+    "01": ("PPL", "People"),
+    "02": ("STL", "Styles"),
+    "03": ("UTL", "Utils"),
+    "04": ("ACT", "Action"),
+    "05": ("BDY", "Body"),
+    "06": ("CHT", "Characters"),
+    "07": ("MCV", "Machines_Vehicles"),
+    "08": ("CLT", "Clothing"),
+    "09": ("ANM", "Animals"),
+    "10": ("BLD", "Buildings"),
+    "11": ("NAT", "Nature"),
+}
+
+WAN_MODE_FOLDERS = {
+    "T2V",
+    "I2V",
+    "V2V",
+    "T2I",
+    "I2I",
+    "IMG2VID",
+    "IMAGE2VIDEO",
+}
+
+
+def normalise_path(path: str) -> str:
+    return os.path.abspath(os.path.normpath(path))
+
+
+def parse_base_and_category(
+    file_path: str,
+    root_dir: str,
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Parse model family and category from the existing library folder shape.
+
+    This preserves the current indexer behaviour while sourcing model-family
+    codes and display names from the Phase 8.9 registry.
+    """
+    root_dir = normalise_path(root_dir)
+    file_path_norm = normalise_path(file_path)
+
+    try:
+        rel_path = os.path.relpath(file_path_norm, root_dir)
+    except ValueError:
+        return None, None, None, None
+
+    parts = rel_path.split(os.sep)
+    if len(parts) < 3:
+        return None, None, None, None
+
+    base_model_folder = parts[0]
+
+    category_index = 1
+    if base_model_folder in ("WAN2.1", "WAN2.2") and len(parts) >= 4:
+        mode_folder = (parts[1] or "").strip().upper()
+        if mode_folder in WAN_MODE_FOLDERS:
+            category_index = 2
+
+    category_folder = parts[category_index]
+
+    base_model_name = base_model_folder
+    base_model_code = None
+    mapped = BASE_MODEL_MAP.get(base_model_folder)
+    if mapped is not None:
+        base_model_code, base_model_name = mapped
+
+    category_code = None
+    category_name = None
+    first_token = category_folder.split(" ")[0].strip()
+    mapped_category = CATEGORY_INDEX_MAP.get(first_token)
+    if mapped_category is not None:
+        category_code, category_name = mapped_category
+    else:
+        category_name = category_folder
+
+    return base_model_name, base_model_code, category_name, category_code

--- a/Database/backend/lora_path_parser.py
+++ b/Database/backend/lora_path_parser.py
@@ -7,6 +7,15 @@ from model_family_registry import base_model_map
 
 BASE_MODEL_MAP = base_model_map()
 
+# Preserve established DB-facing names for existing families. The registry's
+# display names are intended for UI presentation and may include spacing or
+# clarifying labels that should not silently rewrite stored metadata.
+INDEX_NAME_OVERRIDES = {
+    "SD": "SD",
+    "WAN2.1": "WAN2.1",
+    "WAN2.2": "WAN2.2",
+}
+
 CATEGORY_INDEX_MAP: dict[str, tuple[str, str]] = {
     "01": ("PPL", "People"),
     "02": ("STL", "Styles"),
@@ -43,7 +52,7 @@ def parse_base_and_category(
     """Parse model family and category from the existing library folder shape.
 
     This preserves the current indexer behaviour while sourcing model-family
-    codes and display names from the Phase 8.9 registry.
+    codes from the Phase 8.9 registry.
     """
     root_dir = normalise_path(root_dir)
     file_path_norm = normalise_path(file_path)
@@ -71,7 +80,8 @@ def parse_base_and_category(
     base_model_code = None
     mapped = BASE_MODEL_MAP.get(base_model_folder)
     if mapped is not None:
-        base_model_code, base_model_name = mapped
+        base_model_code, display_name = mapped
+        base_model_name = INDEX_NAME_OVERRIDES.get(base_model_folder, display_name)
 
     category_code = None
     category_name = None

--- a/Database/backend/model_family_integration.py
+++ b/Database/backend/model_family_integration.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any
+
+from lora_path_parser import BASE_MODEL_MAP, parse_base_and_category
+
+
+def apply_model_family_registry(indexer_module: ModuleType | Any) -> None:
+    """Apply the approved Phase 8.9 family mapping to the legacy indexer module.
+
+    This is intentionally a narrow integration seam. It changes folder-to-code
+    metadata parsing only. It does not alter scanner selection, block extraction,
+    database schema, stable-ID logic, or indexing execution.
+    """
+    indexer_module.BASE_MODEL_MAP = dict(BASE_MODEL_MAP)
+    indexer_module.parse_base_and_category = parse_base_and_category

--- a/Database/backend/tests/test_lora_path_parser.py
+++ b/Database/backend/tests/test_lora_path_parser.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from lora_path_parser import parse_base_and_category  # noqa: E402
+from model_family_integration import apply_model_family_registry  # noqa: E402
+
+
+def _path(root: Path, *parts: str) -> str:
+    return str(root.joinpath(*parts))
+
+
+def test_new_model_families_parse_as_metadata_codes(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+
+    assert parse_base_and_category(
+        _path(root, "Flux.2-Klein", "03 - Utils", "klein.safetensors"),
+        str(root),
+    ) == ("Flux.2-Klein", "F2K", "Utils", "UTL")
+
+    assert parse_base_and_category(
+        _path(root, "LTXV2", "02 - Styles", "ltx.safetensors"),
+        str(root),
+    ) == ("LTXV2", "LTX", "Styles", "STL")
+
+    assert parse_base_and_category(
+        _path(root, "Z-Image", "05 - Body", "zimage.safetensors"),
+        str(root),
+    ) == ("Z-Image", "ZIM", "Body", "BDY")
+
+
+def test_existing_family_codes_remain_unchanged(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+
+    assert parse_base_and_category(
+        _path(root, "FLUX", "01 - People", "flux.safetensors"),
+        str(root),
+    ) == ("Flux", "FLX", "People", "PPL")
+
+    assert parse_base_and_category(
+        _path(root, "SDXL", "02 - Styles", "sdxl.safetensors"),
+        str(root),
+    ) == ("SDXL", "SDX", "Styles", "STL")
+
+
+def test_wan_mode_folder_parsing_is_preserved(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+
+    assert parse_base_and_category(
+        _path(root, "WAN2.1", "T2V", "04 - Action", "wan.safetensors"),
+        str(root),
+    ) == ("WAN 2.1", "W21", "Action", "ACT")
+
+    assert parse_base_and_category(
+        _path(root, "WAN2.2", "I2V", "05 - Body", "wan.safetensors"),
+        str(root),
+    ) == ("WAN 2.2", "W22", "Body", "BDY")
+
+
+def test_unknown_family_remains_visible_without_invented_code(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+
+    assert parse_base_and_category(
+        _path(root, "FutureModel", "03 - Utils", "future.safetensors"),
+        str(root),
+    ) == ("FutureModel", None, "Utils", "UTL")
+
+
+def test_integration_shim_only_replaces_metadata_parser_contract() -> None:
+    sentinel = object()
+    indexer = SimpleNamespace(
+        BASE_MODEL_MAP={"OLD": ("OLD", "Old")},
+        parse_base_and_category=sentinel,
+        inspect_lora=sentinel,
+        make_flux_layout=sentinel,
+    )
+
+    apply_model_family_registry(indexer)
+
+    assert indexer.BASE_MODEL_MAP["Flux.2-Klein"] == ("F2K", "Flux.2-Klein")
+    assert indexer.BASE_MODEL_MAP["LTXV2"] == ("LTX", "LTXV2")
+    assert indexer.BASE_MODEL_MAP["Z-Image"] == ("ZIM", "Z-Image")
+    assert indexer.parse_base_and_category is parse_base_and_category
+    assert indexer.inspect_lora is sentinel
+    assert indexer.make_flux_layout is sentinel

--- a/Database/backend/tests/test_lora_path_parser.py
+++ b/Database/backend/tests/test_lora_path_parser.py
@@ -35,7 +35,7 @@ def test_new_model_families_parse_as_metadata_codes(tmp_path: Path) -> None:
     ) == ("Z-Image", "ZIM", "Body", "BDY")
 
 
-def test_existing_family_codes_remain_unchanged(tmp_path: Path) -> None:
+def test_existing_family_codes_and_db_names_remain_unchanged(tmp_path: Path) -> None:
     root = tmp_path / "loras"
 
     assert parse_base_and_category(
@@ -44,23 +44,28 @@ def test_existing_family_codes_remain_unchanged(tmp_path: Path) -> None:
     ) == ("Flux", "FLX", "People", "PPL")
 
     assert parse_base_and_category(
+        _path(root, "SD", "03 - Utils", "sd.safetensors"),
+        str(root),
+    ) == ("SD", "SD1", "Utils", "UTL")
+
+    assert parse_base_and_category(
         _path(root, "SDXL", "02 - Styles", "sdxl.safetensors"),
         str(root),
     ) == ("SDXL", "SDX", "Styles", "STL")
 
 
-def test_wan_mode_folder_parsing_is_preserved(tmp_path: Path) -> None:
+def test_wan_mode_folder_parsing_and_db_names_are_preserved(tmp_path: Path) -> None:
     root = tmp_path / "loras"
 
     assert parse_base_and_category(
         _path(root, "WAN2.1", "T2V", "04 - Action", "wan.safetensors"),
         str(root),
-    ) == ("WAN 2.1", "W21", "Action", "ACT")
+    ) == ("WAN2.1", "W21", "Action", "ACT")
 
     assert parse_base_and_category(
         _path(root, "WAN2.2", "I2V", "05 - Body", "wan.safetensors"),
         str(root),
-    ) == ("WAN 2.2", "W22", "Body", "BDY")
+    ) == ("WAN2.2", "W22", "Body", "BDY")
 
 
 def test_unknown_family_remains_visible_without_invented_code(tmp_path: Path) -> None:

--- a/docs/phase89b-indexer-registry-integration.md
+++ b/docs/phase89b-indexer-registry-integration.md
@@ -1,0 +1,59 @@
+# Phase 8.9b indexer registry integration
+
+This slice connects the approved Phase 8.9a model-family registry to the legacy indexer through a narrow, explicit integration seam.
+
+## What changes
+
+- `lora_path_parser.py` preserves the existing folder/category parsing contract while sourcing model-family codes from the canonical registry.
+- `model_family_integration.py` applies only the model mapping and parser function to the legacy `lora_indexer` module.
+- `lora_api_server_docker.py` applies that integration before importing the FastAPI application.
+- `lora_indexer_registered.py` provides an explicit registry-aware CLI entrypoint for future controlled local runs.
+
+## Newly recognised metadata families
+
+| Folder | Code |
+|---|---:|
+| Flux.2-Klein | F2K |
+| LTXV2 | LTX |
+| Z-Image | ZIM |
+
+These families remain metadata-only. The integration does not add a block layout, block extraction, role-aware orchestration, or export support for them.
+
+## Compatibility preservation
+
+Existing DB-facing family names remain unchanged:
+
+- `SD`
+- `WAN2.1`
+- `WAN2.2`
+
+The registry's presentation labels, such as `WAN 2.1`, are not written into index metadata.
+
+WAN mode-folder parsing remains unchanged for T2V, I2V, V2V, T2I, I2I, IMG2VID and IMAGE2VIDEO.
+
+## Safety
+
+This branch does not:
+
+- run a full or partial scan
+- modify the current DB
+- change schema
+- assign stable IDs
+- delete stale rows
+- change scanner selection
+- change block extraction or orchestration maths
+
+The Docker backend will only use the new mapping if a future indexing action is explicitly invoked. Merging or deploying this code does not itself start an index.
+
+## Validation
+
+From **Bender / VS Code PowerShell**:
+
+```powershell
+cd 'E:\LoRA Project'
+
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_model_family_registry.py `
+  Database\backend\tests\test_lora_path_parser.py `
+  -q
+```


### PR DESCRIPTION
## What changed

- Added a registry-backed path parser for model family and category metadata.
- Added an explicit integration shim that applies only the approved family mapping and parser to the legacy indexer module.
- Applied the shim in the Nibbler Docker backend before the API imports its indexer entrypoint.
- Added `lora_indexer_registered.py` as an explicit registry-aware CLI entrypoint for future controlled runs.
- Added tests for F2K, LTX and ZIM parsing, existing family compatibility, WAN mode folders, unknown families and the narrow integration contract.
- Added Phase 8.9b design and safety documentation.

## Newly recognised metadata codes

- `Flux.2-Klein` -> `F2K`
- `LTXV2` -> `LTX`
- `Z-Image` -> `ZIM`

These remain metadata-only. No block layout or extraction support is claimed.

## Compatibility

Existing DB-facing names are preserved exactly for `SD`, `WAN2.1` and `WAN2.2`. Registry UI labels are not silently written into index metadata.

Existing FLX, FLK, ILL, PNY, SD1, SDX, W21 and W22 codes remain unchanged.

## Safety

- No scan was run.
- No DB rows were changed.
- No schema changes.
- No stable IDs were assigned.
- No stale rows were removed.
- No scanner selection changes.
- No block extraction or orchestration maths changes.
- Deploying this code does not start indexing. The new mapping is used only if a future indexing action is explicitly invoked.

## Validation

Verified on Bender from the repository root:

```text
10 passed in 0.45s
```
