### PR TITLE
Phase 8.9e: add guarded metadata reconciler

### DIFF
--- a/Database/backend/phase89e_metadata_reconcile.py
+++ b/Database/backend/phase89e_metadata_reconcile.py
@@ -4,7 +4,6 @@ import argparse
 import hashlib
 import json
 import os
-import shutil
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -49,6 +48,7 @@ class ExecutionPreview:
     backfills: tuple[dict[str, Any], ...]
     id_assignments: tuple[dict[str, Any], ...]
     excluded_scanned_inserts: tuple[dict[str, Any], ...]
+    excluded_id_prefix_backfills: tuple[dict[str, Any], ...]
     excluded_relocations: int
     untouched_stale_rows: int
     untouched_legacy_rows: int
@@ -60,6 +60,7 @@ class ExecutionPreview:
             "metadata_backfills": len(self.backfills),
             "existing_id_assignments": len(self.id_assignments),
             "excluded_scanned_inserts": len(self.excluded_scanned_inserts),
+            "excluded_id_prefix_backfills": len(self.excluded_id_prefix_backfills),
             "excluded_relocations": self.excluded_relocations,
             "untouched_stale_rows": self.untouched_stale_rows,
             "untouched_legacy_rows": self.untouched_legacy_rows,
@@ -85,6 +86,16 @@ def plan_sha256(plan: Mapping[str, Any]) -> str:
 
 def _normalise_code(value: Any) -> str:
     return str(value or "").strip().upper()
+
+
+def _stable_id_base_prefix(value: Any) -> str | None:
+    stable_id = str(value or "").strip().upper()
+    if not stable_id:
+        return None
+    parts = stable_id.split("-")
+    if len(parts) != 3 or len(parts[0]) != 3:
+        return None
+    return parts[0]
 
 
 def _planned_id_lookup(plan: Mapping[str, Any]) -> dict[tuple[str, str], str]:
@@ -142,6 +153,7 @@ def build_execution_preview(plan: Mapping[str, Any]) -> ExecutionPreview:
         inserts.append(item)
 
     backfills: list[dict[str, Any]] = []
+    excluded_prefix_backfills: list[dict[str, Any]] = []
     for raw in plan.get("mounted_metadata_backfill_candidates", []):
         item = dict(raw)
         changed_fields = item.get("changed_fields") or {}
@@ -150,6 +162,18 @@ def build_execution_preview(plan: Mapping[str, Any]) -> ExecutionPreview:
             raise ReconcileError(
                 f"Backfill row {item.get('row_id')} contains unapproved field(s): {', '.join(unexpected)}"
             )
+
+        base_transition = changed_fields.get("base_model_code")
+        if base_transition:
+            new_code = _normalise_code(base_transition.get("to"))
+            stable_prefix = _stable_id_base_prefix(item.get("stable_id"))
+            if stable_prefix and stable_prefix != new_code:
+                item["exclusion_reason"] = (
+                    f"existing stable_id prefix {stable_prefix} conflicts with proposed base_model_code {new_code}"
+                )
+                excluded_prefix_backfills.append(item)
+                continue
+
         if changed_fields:
             backfills.append(item)
 
@@ -174,6 +198,7 @@ def build_execution_preview(plan: Mapping[str, Any]) -> ExecutionPreview:
         backfills=tuple(backfills),
         id_assignments=tuple(id_assignments),
         excluded_scanned_inserts=tuple(excluded_scanned),
+        excluded_id_prefix_backfills=tuple(excluded_prefix_backfills),
         excluded_relocations=excluded_relocations,
         untouched_stale_rows=int(summary.get("untouched_stale_current_family_rows") or 0),
         untouched_legacy_rows=int(summary.get("untouched_legacy_unmounted_rows") or 0),
@@ -414,6 +439,7 @@ def apply_preview(
         "metadata_backfills": backfilled,
         "existing_id_assignments": ids_assigned,
         "excluded_scanned_inserts": len(preview.excluded_scanned_inserts),
+        "excluded_id_prefix_backfills": len(preview.excluded_id_prefix_backfills),
         "excluded_relocations": preview.excluded_relocations,
     }
 
@@ -427,6 +453,7 @@ def print_preview(preview: ExecutionPreview) -> None:
     print(f"Metadata backfills           : {summary['metadata_backfills']}")
     print(f"Existing ID assignments      : {summary['existing_id_assignments']}")
     print(f"Excluded FLX/FLK inserts     : {summary['excluded_scanned_inserts']}")
+    print(f"Excluded ID-prefix backfills : {summary['excluded_id_prefix_backfills']}")
     print(f"Excluded relocations         : {summary['excluded_relocations']}")
     print(f"Untouched stale rows         : {summary['untouched_stale_rows']}")
     print(f"Untouched legacy rows        : {summary['untouched_legacy_rows']}")

--- a/Database/backend/phase89e_metadata_reconcile.py
+++ b/Database/backend/phase89e_metadata_reconcile.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+
+ALLOWED_INSERT_BASE_CODES = frozenset({"F2K", "ILL", "LTX", "PNY", "SDX", "W22", "ZIM"})
+EXCLUDED_SCANNED_BASE_CODES = frozenset({"FLX", "FLK"})
+ALLOWED_BACKFILL_FIELDS = frozenset({"base_model_code", "category_name"})
+REQUIRED_LORA_COLUMNS = frozenset(
+    {
+        "id",
+        "file_path",
+        "filename",
+        "base_model_name",
+        "base_model_code",
+        "category_name",
+        "category_code",
+        "model_family",
+        "lora_type",
+        "rank",
+        "has_block_weights",
+        "block_layout",
+        "clip_contributor",
+        "clip_tensor_count",
+        "last_modified",
+        "created_at",
+        "updated_at",
+        "stable_id",
+    }
+)
+
+
+class ReconcileError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ExecutionPreview:
+    plan_sha256: str
+    inserts: tuple[dict[str, Any], ...]
+    backfills: tuple[dict[str, Any], ...]
+    id_assignments: tuple[dict[str, Any], ...]
+    excluded_scanned_inserts: tuple[dict[str, Any], ...]
+    excluded_relocations: int
+    untouched_stale_rows: int
+    untouched_legacy_rows: int
+
+    def summary(self) -> dict[str, int | str]:
+        return {
+            "plan_sha256": self.plan_sha256,
+            "metadata_inserts": len(self.inserts),
+            "metadata_backfills": len(self.backfills),
+            "existing_id_assignments": len(self.id_assignments),
+            "excluded_scanned_inserts": len(self.excluded_scanned_inserts),
+            "excluded_relocations": self.excluded_relocations,
+            "untouched_stale_rows": self.untouched_stale_rows,
+            "untouched_legacy_rows": self.untouched_legacy_rows,
+        }
+
+
+def load_plan(path: str | os.PathLike[str]) -> dict[str, Any]:
+    plan_path = Path(path).expanduser().resolve(strict=True)
+    with plan_path.open("r", encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ReconcileError("Plan JSON must contain an object at the top level")
+    return plan
+
+
+def canonical_plan_bytes(plan: Mapping[str, Any]) -> bytes:
+    return json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def plan_sha256(plan: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_plan_bytes(plan)).hexdigest()
+
+
+def _normalise_code(value: Any) -> str:
+    return str(value or "").strip().upper()
+
+
+def _planned_id_lookup(plan: Mapping[str, Any]) -> dict[tuple[str, str], str]:
+    lookup: dict[tuple[str, str], str] = {}
+    for item in plan.get("planned_stable_ids", []):
+        if not isinstance(item, Mapping):
+            continue
+        source_type = str(item.get("source_type") or "")
+        stable_id = str(item.get("planned_stable_id") or "").strip().upper()
+        if not source_type or not stable_id:
+            continue
+        if source_type == "new_metadata_insert":
+            key = str(item.get("relative_path") or "").casefold()
+        elif source_type == "existing_mounted_row_missing_id":
+            key = str(item.get("row_id") or "")
+        else:
+            continue
+        lookup[(source_type, key)] = stable_id
+    return lookup
+
+
+def build_execution_preview(plan: Mapping[str, Any]) -> ExecutionPreview:
+    if plan.get("audit_mode") != "read-only":
+        raise ReconcileError("Phase 8.9e accepts only a Phase 8.9d read-only plan")
+
+    safety = plan.get("safety") or {}
+    if safety.get("writes_database") is not False or safety.get("runs_indexer") is not False:
+        raise ReconcileError("Plan safety flags do not describe a read-only planner run")
+
+    blockers = {
+        "unresolved_relocations": plan.get("unresolved_relocations") or [],
+        "stable_id_groups_exhausted": plan.get("stable_id_groups_exhausted") or [],
+        "existing_stable_id_issues": plan.get("existing_stable_id_issues") or [],
+    }
+    active_blockers = {name: values for name, values in blockers.items() if values}
+    if active_blockers:
+        raise ReconcileError(f"Plan has unresolved blockers: {', '.join(sorted(active_blockers))}")
+
+    ids = _planned_id_lookup(plan)
+    inserts: list[dict[str, Any]] = []
+    excluded_scanned: list[dict[str, Any]] = []
+    for raw in plan.get("new_metadata_insert_candidates", []):
+        item = dict(raw)
+        code = _normalise_code(item.get("base_model_code"))
+        if code in EXCLUDED_SCANNED_BASE_CODES:
+            excluded_scanned.append(item)
+            continue
+        if code not in ALLOWED_INSERT_BASE_CODES:
+            raise ReconcileError(f"Insert candidate uses unapproved base-model code: {code or 'NULL'}")
+        relative = str(item.get("relative_path") or "")
+        stable_id = ids.get(("new_metadata_insert", relative.casefold()))
+        if not stable_id:
+            raise ReconcileError(f"No planned stable ID for insert candidate: {relative}")
+        item["planned_stable_id"] = stable_id
+        inserts.append(item)
+
+    backfills: list[dict[str, Any]] = []
+    for raw in plan.get("mounted_metadata_backfill_candidates", []):
+        item = dict(raw)
+        changed_fields = item.get("changed_fields") or {}
+        unexpected = sorted(set(changed_fields) - ALLOWED_BACKFILL_FIELDS)
+        if unexpected:
+            raise ReconcileError(
+                f"Backfill row {item.get('row_id')} contains unapproved field(s): {', '.join(unexpected)}"
+            )
+        if changed_fields:
+            backfills.append(item)
+
+    id_assignments: list[dict[str, Any]] = []
+    for raw in plan.get("mounted_existing_rows_missing_stable_id", []):
+        item = dict(raw)
+        row_key = str(item.get("row_id") or "")
+        stable_id = ids.get(("existing_mounted_row_missing_id", row_key))
+        if not stable_id:
+            raise ReconcileError(f"No planned stable ID for existing row {row_key}")
+        item["planned_stable_id"] = stable_id
+        id_assignments.append(item)
+
+    summary = plan.get("summary") or {}
+    excluded_relocations = len(plan.get("same_family_relocations") or []) + len(
+        plan.get("cross_family_reclassifications") or []
+    )
+
+    return ExecutionPreview(
+        plan_sha256=plan_sha256(plan),
+        inserts=tuple(inserts),
+        backfills=tuple(backfills),
+        id_assignments=tuple(id_assignments),
+        excluded_scanned_inserts=tuple(excluded_scanned),
+        excluded_relocations=excluded_relocations,
+        untouched_stale_rows=int(summary.get("untouched_stale_current_family_rows") or 0),
+        untouched_legacy_rows=int(summary.get("untouched_legacy_unmounted_rows") or 0),
+    )
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _check_schema(conn: sqlite3.Connection) -> None:
+    columns = _table_columns(conn, "lora")
+    missing = sorted(REQUIRED_LORA_COLUMNS - columns)
+    if missing:
+        raise ReconcileError(f"lora table is missing required column(s): {', '.join(missing)}")
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _create_backup(db_path: Path, backup_dir: Path, digest: str) -> Path:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = backup_dir / f"{db_path.stem}.phase89e.{stamp}.{digest[:12]}.db"
+    if backup_path.exists():
+        raise ReconcileError(f"Backup path already exists: {backup_path}")
+
+    source = sqlite3.connect(db_path)
+    try:
+        destination = sqlite3.connect(backup_path)
+        try:
+            source.backup(destination)
+        finally:
+            destination.close()
+    finally:
+        source.close()
+
+    if not backup_path.is_file() or backup_path.stat().st_size == 0:
+        raise ReconcileError("SQLite backup was not created correctly")
+    return backup_path
+
+
+def _same_db_value(actual: Any, expected: Any) -> bool:
+    if actual is None and expected in (None, ""):
+        return True
+    return actual == expected
+
+
+def _assert_stable_id_available(conn: sqlite3.Connection, stable_id: str, *, except_row_id: int | None = None) -> None:
+    if except_row_id is None:
+        row = conn.execute("SELECT id FROM lora WHERE stable_id = ?", (stable_id,)).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT id FROM lora WHERE stable_id = ? AND id <> ?",
+            (stable_id, except_row_id),
+        ).fetchone()
+    if row is not None:
+        raise ReconcileError(f"Stable ID is already in use: {stable_id}")
+
+
+def _apply_backfills(conn: sqlite3.Connection, items: Iterable[Mapping[str, Any]], now: str) -> int:
+    count = 0
+    for item in items:
+        row_id = int(item["row_id"])
+        row = conn.execute("SELECT * FROM lora WHERE id = ?", (row_id,)).fetchone()
+        if row is None:
+            raise ReconcileError(f"Backfill row no longer exists: {row_id}")
+        if str(row["file_path"]) != str(item.get("file_path")):
+            raise ReconcileError(f"Backfill row {row_id} file_path changed since planning")
+
+        assignments: list[str] = []
+        values: list[Any] = []
+        for field, transition in (item.get("changed_fields") or {}).items():
+            if field not in ALLOWED_BACKFILL_FIELDS:
+                raise ReconcileError(f"Backfill field is not approved: {field}")
+            expected_old = transition.get("from")
+            new_value = transition.get("to")
+            if not _same_db_value(row[field], expected_old):
+                raise ReconcileError(
+                    f"Backfill row {row_id} field {field} changed since planning: "
+                    f"expected {expected_old!r}, found {row[field]!r}"
+                )
+            assignments.append(f"{field} = ?")
+            values.append(new_value)
+
+        if not assignments:
+            continue
+        assignments.append("updated_at = ?")
+        values.extend([now, row_id])
+        conn.execute(f"UPDATE lora SET {', '.join(assignments)} WHERE id = ?", values)
+        count += 1
+    return count
+
+
+def _apply_existing_ids(conn: sqlite3.Connection, items: Iterable[Mapping[str, Any]], now: str) -> int:
+    count = 0
+    for item in items:
+        row_id = int(item["row_id"])
+        planned_id = str(item["planned_stable_id"]).upper()
+        row = conn.execute(
+            "SELECT id, file_path, base_model_code, category_code, stable_id FROM lora WHERE id = ?",
+            (row_id,),
+        ).fetchone()
+        if row is None:
+            raise ReconcileError(f"ID-assignment row no longer exists: {row_id}")
+        if str(row["file_path"]) != str(item.get("file_path")):
+            raise ReconcileError(f"ID-assignment row {row_id} file_path changed since planning")
+        if str(row["stable_id"] or "").strip():
+            raise ReconcileError(f"ID-assignment row {row_id} already has stable_id {row['stable_id']}")
+        if _normalise_code(row["base_model_code"]) != _normalise_code(item.get("base_model_code")):
+            raise ReconcileError(f"ID-assignment row {row_id} base_model_code does not match the plan")
+        if _normalise_code(row["category_code"]) != _normalise_code(item.get("category_code")):
+            raise ReconcileError(f"ID-assignment row {row_id} category_code does not match the plan")
+        _assert_stable_id_available(conn, planned_id, except_row_id=row_id)
+        conn.execute(
+            "UPDATE lora SET stable_id = ?, updated_at = ? WHERE id = ?",
+            (planned_id, now, row_id),
+        )
+        count += 1
+    return count
+
+
+def _db_file_path(db_root: str, relative: str) -> str:
+    root = str(db_root or "").replace("\\", "/").rstrip("/")
+    rel = PurePosixPath(relative).as_posix().lstrip("/")
+    return f"{root}/{rel}" if root else rel
+
+
+def _apply_inserts(
+    conn: sqlite3.Connection,
+    items: Iterable[Mapping[str, Any]],
+    *,
+    library_root: Path,
+    db_path_root: str,
+    now: str,
+) -> int:
+    count = 0
+    for item in items:
+        relative = PurePosixPath(str(item["relative_path"])).as_posix()
+        source_path = library_root.joinpath(*PurePosixPath(relative).parts)
+        if not source_path.is_file():
+            raise ReconcileError(f"Insert source file is missing: {source_path}")
+
+        file_path = _db_file_path(db_path_root, relative)
+        if conn.execute("SELECT id FROM lora WHERE file_path = ?", (file_path,)).fetchone() is not None:
+            raise ReconcileError(f"Insert file_path already exists in DB: {file_path}")
+
+        stable_id = str(item["planned_stable_id"]).upper()
+        _assert_stable_id_available(conn, stable_id)
+        stat = source_path.stat()
+        conn.execute(
+            """
+            INSERT INTO lora (
+                file_path, filename,
+                base_model_name, base_model_code,
+                category_name, category_code,
+                model_family, lora_type, rank,
+                has_block_weights, block_layout,
+                clip_contributor, clip_tensor_count,
+                last_modified, created_at, updated_at,
+                stable_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                file_path,
+                item.get("filename") or PurePosixPath(relative).name,
+                item.get("base_model_name"),
+                _normalise_code(item.get("base_model_code")),
+                item.get("category_name"),
+                _normalise_code(item.get("category_code")),
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                float(stat.st_mtime),
+                now,
+                now,
+                stable_id,
+            ),
+        )
+        count += 1
+    return count
+
+
+def apply_preview(
+    preview: ExecutionPreview,
+    *,
+    db_path: str | os.PathLike[str],
+    library_root: str | os.PathLike[str],
+    db_path_root: str,
+    backup_dir: str | os.PathLike[str],
+    expected_plan_sha256: str,
+) -> dict[str, Any]:
+    expected = str(expected_plan_sha256 or "").strip().lower()
+    if expected != preview.plan_sha256:
+        raise ReconcileError(
+            f"Plan digest mismatch: expected argument {expected or 'EMPTY'}, actual {preview.plan_sha256}"
+        )
+
+    db = Path(db_path).expanduser().resolve(strict=True)
+    root = Path(library_root).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise ReconcileError(f"LoRA library root is not a directory: {root}")
+
+    backup_path = _create_backup(db, Path(backup_dir).expanduser().resolve(), preview.plan_sha256)
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 10000")
+
+    try:
+        _check_schema(conn)
+        conn.execute("BEGIN IMMEDIATE")
+        now = _timestamp()
+        backfilled = _apply_backfills(conn, preview.backfills, now)
+        ids_assigned = _apply_existing_ids(conn, preview.id_assignments, now)
+        inserted = _apply_inserts(
+            conn,
+            preview.inserts,
+            library_root=root,
+            db_path_root=db_path_root,
+            now=now,
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return {
+        "backup_path": str(backup_path),
+        "metadata_inserts": inserted,
+        "metadata_backfills": backfilled,
+        "existing_id_assignments": ids_assigned,
+        "excluded_scanned_inserts": len(preview.excluded_scanned_inserts),
+        "excluded_relocations": preview.excluded_relocations,
+    }
+
+
+def print_preview(preview: ExecutionPreview) -> None:
+    summary = preview.summary()
+    print("=== Phase 8.9e controlled metadata reconciliation ===")
+    print("Mode                         : dry-run")
+    print(f"Plan SHA-256                 : {summary['plan_sha256']}")
+    print(f"Metadata inserts             : {summary['metadata_inserts']}")
+    print(f"Metadata backfills           : {summary['metadata_backfills']}")
+    print(f"Existing ID assignments      : {summary['existing_id_assignments']}")
+    print(f"Excluded FLX/FLK inserts     : {summary['excluded_scanned_inserts']}")
+    print(f"Excluded relocations         : {summary['excluded_relocations']}")
+    print(f"Untouched stale rows         : {summary['untouched_stale_rows']}")
+    print(f"Untouched legacy rows        : {summary['untouched_legacy_rows']}")
+    print()
+    print("No database changes were made.")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guarded Phase 8.9e metadata reconciliation")
+    parser.add_argument("--plan", required=True, help="Phase 8.9d JSON plan")
+    parser.add_argument("--db", required=True, help="SQLite database path")
+    parser.add_argument("--root", required=True, help="Mounted LoRA library root")
+    parser.add_argument("--db-path-root", default="/loras", help="Path prefix stored in SQLite for new rows")
+    parser.add_argument("--apply", action="store_true", help="Apply the approved metadata-only scope")
+    parser.add_argument("--expected-plan-sha256", help="Required with --apply")
+    parser.add_argument("--backup-dir", help="Required with --apply")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    plan = load_plan(args.plan)
+    preview = build_execution_preview(plan)
+    if not args.apply:
+        print_preview(preview)
+        return 0
+
+    if not args.expected_plan_sha256:
+        raise SystemExit("--expected-plan-sha256 is required with --apply")
+    if not args.backup_dir:
+        raise SystemExit("--backup-dir is required with --apply")
+
+    result = apply_preview(
+        preview,
+        db_path=args.db,
+        library_root=args.root,
+        db_path_root=args.db_path_root,
+        backup_dir=args.backup_dir,
+        expected_plan_sha256=args.expected_plan_sha256,
+    )
+    print("=== Phase 8.9e apply complete ===")
+    for key, value in result.items():
+        print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Database/backend/tests/test_phase89e_metadata_reconcile.py
+++ b/Database/backend/tests/test_phase89e_metadata_reconcile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 import sqlite3
 import sys
@@ -102,6 +101,26 @@ def _create_db(path: Path) -> None:
                 "2026-07-26T00:00:00+00:00",
                 "W21-ACT-001",
             ),
+            (
+                3,
+                "/loras/Z-Image/05 - Body/existing-zimage.safetensors",
+                "existing-zimage.safetensors",
+                "Z-Image",
+                None,
+                "Body",
+                "BDY",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                "UNK-BDY-001",
+            ),
         ],
     )
     conn.commit()
@@ -157,15 +176,24 @@ def _plan() -> dict:
         "mounted_metadata_backfill_candidates": [
             {
                 "row_id": 1,
+                "stable_id": None,
                 "file_path": "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
                 "parsed_base_model_code": "F2K",
                 "changed_fields": {"base_model_code": {"from": None, "to": "F2K"}},
             },
             {
                 "row_id": 2,
+                "stable_id": "W21-ACT-001",
                 "file_path": "/loras/WAN2.1/T2V/04 - Action/existing-wan.safetensors",
                 "parsed_base_model_code": "W21",
                 "changed_fields": {"category_name": {"from": "04 - Action", "to": "Action"}},
+            },
+            {
+                "row_id": 3,
+                "stable_id": "UNK-BDY-001",
+                "file_path": "/loras/Z-Image/05 - Body/existing-zimage.safetensors",
+                "parsed_base_model_code": "ZIM",
+                "changed_fields": {"base_model_code": {"from": None, "to": "ZIM"}},
             },
         ],
         "mounted_existing_rows_missing_stable_id": [
@@ -215,13 +243,16 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
     return root, db, backups
 
 
-def test_preview_excludes_scanned_families_and_all_relocations() -> None:
+def test_preview_excludes_scanned_families_relocations_and_prefix_conflicts() -> None:
     preview = build_execution_preview(_plan())
 
     assert len(preview.inserts) == 2
     assert {item["base_model_code"] for item in preview.inserts} == {"F2K", "W22"}
     assert len(preview.excluded_scanned_inserts) == 1
     assert preview.excluded_scanned_inserts[0]["base_model_code"] == "FLX"
+    assert len(preview.excluded_id_prefix_backfills) == 1
+    assert preview.excluded_id_prefix_backfills[0]["row_id"] == 3
+    assert "UNK" in preview.excluded_id_prefix_backfills[0]["exclusion_reason"]
     assert preview.excluded_relocations == 23
     assert len(preview.backfills) == 2
     assert len(preview.id_assignments) == 1
@@ -263,6 +294,7 @@ def test_apply_creates_backup_and_only_applies_approved_scope(tmp_path: Path) ->
     assert result["metadata_backfills"] == 2
     assert result["existing_id_assignments"] == 1
     assert result["excluded_scanned_inserts"] == 1
+    assert result["excluded_id_prefix_backfills"] == 1
     assert result["excluded_relocations"] == 23
     assert Path(result["backup_path"]).is_file()
 
@@ -275,11 +307,13 @@ def test_apply_creates_backup_and_only_applies_approved_scope(tmp_path: Path) ->
     assert by_filename["existing-klein.safetensors"]["base_model_code"] == "F2K"
     assert by_filename["existing-klein.safetensors"]["stable_id"] == "F2K-UTL-001"
     assert by_filename["existing-wan.safetensors"]["category_name"] == "Action"
+    assert by_filename["existing-zimage.safetensors"]["base_model_code"] is None
+    assert by_filename["existing-zimage.safetensors"]["stable_id"] == "UNK-BDY-001"
     assert by_filename["new-klein.safetensors"]["stable_id"] == "F2K-UTL-002"
     assert by_filename["new-klein.safetensors"]["clip_tensor_count"] == -1
     assert by_filename["new-wan.safetensors"]["stable_id"] == "W22-BDY-001"
     assert "needs-scanner.safetensors" not in by_filename
-    assert len(rows) == 4
+    assert len(rows) == 5
 
 
 def test_compare_and_swap_guard_rolls_back_transaction(tmp_path: Path) -> None:

--- a/Database/backend/tests/test_phase89e_metadata_reconcile.py
+++ b/Database/backend/tests/test_phase89e_metadata_reconcile.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+import sys
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from phase89e_metadata_reconcile import (  # noqa: E402
+    ReconcileError,
+    apply_preview,
+    build_execution_preview,
+)
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"test")
+
+
+def _create_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            filename TEXT NOT NULL,
+            base_model_name TEXT,
+            base_model_code TEXT,
+            category_name TEXT,
+            category_code TEXT,
+            model_family TEXT,
+            lora_type TEXT,
+            rank INTEGER,
+            has_block_weights INTEGER NOT NULL DEFAULT 0,
+            block_layout TEXT,
+            clip_contributor INTEGER NOT NULL DEFAULT 0,
+            clip_tensor_count INTEGER NOT NULL DEFAULT -1,
+            last_modified REAL NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            stable_id TEXT
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO lora (
+            id, file_path, filename,
+            base_model_name, base_model_code,
+            category_name, category_code,
+            model_family, lora_type, rank,
+            has_block_weights, block_layout,
+            clip_contributor, clip_tensor_count,
+            last_modified, created_at, updated_at, stable_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                1,
+                "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "existing-klein.safetensors",
+                "Flux.2-Klein",
+                None,
+                "Utils",
+                "UTL",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                None,
+            ),
+            (
+                2,
+                "/loras/WAN2.1/T2V/04 - Action/existing-wan.safetensors",
+                "existing-wan.safetensors",
+                "WAN2.1",
+                "W21",
+                "04 - Action",
+                "ACT",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                "W21-ACT-001",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _plan() -> dict:
+    return {
+        "audit_mode": "read-only",
+        "summary": {
+            "untouched_stale_current_family_rows": 668,
+            "untouched_legacy_unmounted_rows": 114,
+        },
+        "safety": {
+            "writes_database": False,
+            "runs_indexer": False,
+            "assigns_stable_ids": False,
+        },
+        "unresolved_relocations": [],
+        "stable_id_groups_exhausted": [],
+        "existing_stable_id_issues": [],
+        "same_family_relocations": [{"row_id": 10}, {"row_id": 11}, {"row_id": 12}],
+        "cross_family_reclassifications": [{"row_id": row_id} for row_id in range(20, 40)],
+        "new_metadata_insert_candidates": [
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "Flux.2-Klein/03 - Utils/new-klein.safetensors",
+                "filename": "new-klein.safetensors",
+                "base_model_name": "Flux.2-Klein",
+                "base_model_code": "F2K",
+                "category_name": "Utils",
+                "category_code": "UTL",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "WAN2.2/I2V/05 - Body/new-wan.safetensors",
+                "filename": "new-wan.safetensors",
+                "base_model_name": "WAN2.2",
+                "base_model_code": "W22",
+                "category_name": "Body",
+                "category_code": "BDY",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "FLUX/01 - People/needs-scanner.safetensors",
+                "filename": "needs-scanner.safetensors",
+                "base_model_name": "Flux",
+                "base_model_code": "FLX",
+                "category_name": "People",
+                "category_code": "PPL",
+            },
+        ],
+        "mounted_metadata_backfill_candidates": [
+            {
+                "row_id": 1,
+                "file_path": "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "parsed_base_model_code": "F2K",
+                "changed_fields": {"base_model_code": {"from": None, "to": "F2K"}},
+            },
+            {
+                "row_id": 2,
+                "file_path": "/loras/WAN2.1/T2V/04 - Action/existing-wan.safetensors",
+                "parsed_base_model_code": "W21",
+                "changed_fields": {"category_name": {"from": "04 - Action", "to": "Action"}},
+            },
+        ],
+        "mounted_existing_rows_missing_stable_id": [
+            {
+                "source_type": "existing_mounted_row_missing_id",
+                "row_id": 1,
+                "file_path": "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "relative_path": "Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "filename": "existing-klein.safetensors",
+                "base_model_code": "F2K",
+                "category_code": "UTL",
+            }
+        ],
+        "planned_stable_ids": [
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "Flux.2-Klein/03 - Utils/new-klein.safetensors",
+                "planned_stable_id": "F2K-UTL-002",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "WAN2.2/I2V/05 - Body/new-wan.safetensors",
+                "planned_stable_id": "W22-BDY-001",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "FLUX/01 - People/needs-scanner.safetensors",
+                "planned_stable_id": "FLX-PPL-001",
+            },
+            {
+                "source_type": "existing_mounted_row_missing_id",
+                "row_id": 1,
+                "planned_stable_id": "F2K-UTL-001",
+            },
+        ],
+    }
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+    backups = tmp_path / "backups"
+    _touch(root / "Flux.2-Klein" / "03 - Utils" / "new-klein.safetensors")
+    _touch(root / "WAN2.2" / "I2V" / "05 - Body" / "new-wan.safetensors")
+    _touch(root / "FLUX" / "01 - People" / "needs-scanner.safetensors")
+    _create_db(db)
+    return root, db, backups
+
+
+def test_preview_excludes_scanned_families_and_all_relocations() -> None:
+    preview = build_execution_preview(_plan())
+
+    assert len(preview.inserts) == 2
+    assert {item["base_model_code"] for item in preview.inserts} == {"F2K", "W22"}
+    assert len(preview.excluded_scanned_inserts) == 1
+    assert preview.excluded_scanned_inserts[0]["base_model_code"] == "FLX"
+    assert preview.excluded_relocations == 23
+    assert len(preview.backfills) == 2
+    assert len(preview.id_assignments) == 1
+    assert preview.untouched_stale_rows == 668
+    assert preview.untouched_legacy_rows == 114
+
+
+def test_wrong_digest_refuses_apply_before_backup(tmp_path: Path) -> None:
+    root, db, backups = _fixture(tmp_path)
+    preview = build_execution_preview(_plan())
+
+    with pytest.raises(ReconcileError, match="Plan digest mismatch"):
+        apply_preview(
+            preview,
+            db_path=db,
+            library_root=root,
+            db_path_root="/loras",
+            backup_dir=backups,
+            expected_plan_sha256="0" * 64,
+        )
+
+    assert not backups.exists()
+
+
+def test_apply_creates_backup_and_only_applies_approved_scope(tmp_path: Path) -> None:
+    root, db, backups = _fixture(tmp_path)
+    preview = build_execution_preview(_plan())
+
+    result = apply_preview(
+        preview,
+        db_path=db,
+        library_root=root,
+        db_path_root="/loras",
+        backup_dir=backups,
+        expected_plan_sha256=preview.plan_sha256,
+    )
+
+    assert result["metadata_inserts"] == 2
+    assert result["metadata_backfills"] == 2
+    assert result["existing_id_assignments"] == 1
+    assert result["excluded_scanned_inserts"] == 1
+    assert result["excluded_relocations"] == 23
+    assert Path(result["backup_path"]).is_file()
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    rows = [dict(row) for row in conn.execute("SELECT * FROM lora ORDER BY id")]
+    conn.close()
+
+    by_filename = {row["filename"]: row for row in rows}
+    assert by_filename["existing-klein.safetensors"]["base_model_code"] == "F2K"
+    assert by_filename["existing-klein.safetensors"]["stable_id"] == "F2K-UTL-001"
+    assert by_filename["existing-wan.safetensors"]["category_name"] == "Action"
+    assert by_filename["new-klein.safetensors"]["stable_id"] == "F2K-UTL-002"
+    assert by_filename["new-klein.safetensors"]["clip_tensor_count"] == -1
+    assert by_filename["new-wan.safetensors"]["stable_id"] == "W22-BDY-001"
+    assert "needs-scanner.safetensors" not in by_filename
+    assert len(rows) == 4
+
+
+def test_compare_and_swap_guard_rolls_back_transaction(tmp_path: Path) -> None:
+    root, db, backups = _fixture(tmp_path)
+    preview = build_execution_preview(_plan())
+
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE lora SET category_name = 'Changed elsewhere' WHERE id = 2")
+    conn.commit()
+    before = conn.execute("SELECT id, base_model_code, category_name, stable_id FROM lora ORDER BY id").fetchall()
+    conn.close()
+
+    with pytest.raises(ReconcileError, match="changed since planning"):
+        apply_preview(
+            preview,
+            db_path=db,
+            library_root=root,
+            db_path_root="/loras",
+            backup_dir=backups,
+            expected_plan_sha256=preview.plan_sha256,
+        )
+
+    conn = sqlite3.connect(db)
+    after = conn.execute("SELECT id, base_model_code, category_name, stable_id FROM lora ORDER BY id").fetchall()
+    conn.close()
+    assert after == before

--- a/docs/phase89e-controlled-metadata-reconcile.md
+++ b/docs/phase89e-controlled-metadata-reconcile.md
@@ -16,10 +16,10 @@ The read-only plan reported:
 - 668 untouched stale current-family rows
 - 114 untouched legacy/unmounted rows
 
-The Phase 8.9e executor narrows this to:
+Before the stable-ID prefix guard is evaluated, the Phase 8.9e candidate scope is:
 
 - **308 metadata-only inserts**
-- **79 metadata backfills**
+- **up to 79 metadata backfills**
 - **2 existing stable-ID assignments**
 
 It explicitly excludes:
@@ -28,6 +28,8 @@ It explicitly excludes:
 - all 23 relocation candidates
 - all stale rows
 - all legacy/unmounted rows
+
+The final backfill count is determined by the Phase 8.9e dry-run. Any base-model correction that would conflict with an existing stable-ID family prefix is excluded automatically.
 
 ## Approved insert families
 
@@ -59,6 +61,16 @@ The executor rejects any plan containing a backfill field outside:
 
 Every update uses a compare-and-swap guard. The row ID, file path and planned old value must still match the database before the new value is written.
 
+### Stable-ID prefix guard
+
+A `base_model_code` correction is not applied automatically when the row already has a stable ID whose family prefix disagrees with the proposed code.
+
+For example, a row with stable ID `UNK-BDY-001` cannot be silently changed to base-model code `ZIM`. That would leave an identity that says `UNK` attached to metadata that says `ZIM`.
+
+Such rows are reported as `excluded_id_prefix_backfills` and remain untouched pending a separate stable-ID continuity policy.
+
+Rows with no stable ID, including the two known F2K rows, remain eligible for metadata correction followed by their planned ID assignment in the same transaction.
+
 ## Relocation policy
 
 No relocation is applied in Phase 8.9e.
@@ -83,7 +95,8 @@ Apply mode requires all of the following:
 7. A `BEGIN IMMEDIATE` transaction.
 8. Compare-and-swap validation for every backfill and existing ID assignment.
 9. Stable-ID collision checks for every inserted or assigned ID.
-10. A rollback on any mismatch or error.
+10. Automatic exclusion of stable-ID/base-code prefix conflicts.
+11. A rollback on any mismatch or error.
 
 The executor never:
 
@@ -92,6 +105,7 @@ The executor never:
 - inserts FLX/FLK records through the metadata path
 - changes scanner or orchestration maths
 - updates relocation rows
+- changes a base-model code across a conflicting stable-ID prefix
 - deletes stale or legacy rows
 - modifies the database schema
 
@@ -117,7 +131,18 @@ python3 phase89e_metadata_reconcile.py \
   --db-path-root /loras
 ```
 
-This prints the plan digest and filtered execution counts. It makes no changes.
+This prints:
+
+- the exact plan SHA-256
+- approved metadata insert count
+- approved metadata backfill count
+- existing ID-assignment count
+- excluded FLX/FLK insert count
+- excluded stable-ID-prefix backfill count
+- excluded relocation count
+- untouched stale and legacy counts
+
+It makes no changes.
 
 ## Apply command
 

--- a/docs/phase89e-controlled-metadata-reconcile.md
+++ b/docs/phase89e-controlled-metadata-reconcile.md
@@ -1,0 +1,148 @@
+# Phase 8.9e controlled metadata reconciliation
+
+This phase introduces a guarded, write-capable metadata reconciler. It does not run automatically and remains dry-run by default.
+
+The reconciler consumes the exact Phase 8.9d JSON plan and applies only the approved metadata scope after explicit operator approval.
+
+## Live scope established on 26 July 2026
+
+The read-only plan reported:
+
+- 311 new metadata insert candidates
+- 79 mounted metadata backfill candidates
+- 2 existing mounted rows missing stable IDs
+- 3 same-family relocation candidates
+- 20 cross-family reclassification candidates
+- 668 untouched stale current-family rows
+- 114 untouched legacy/unmounted rows
+
+The Phase 8.9e executor narrows this to:
+
+- **308 metadata-only inserts**
+- **79 metadata backfills**
+- **2 existing stable-ID assignments**
+
+It explicitly excludes:
+
+- 3 FLX files, because they require the real Flux scanner rather than metadata-only insertion
+- all 23 relocation candidates
+- all stale rows
+- all legacy/unmounted rows
+
+## Approved insert families
+
+Metadata-only insertion is allowed only for:
+
+- F2K
+- ILL
+- LTX
+- PNY
+- SDX
+- W22
+- ZIM
+
+FLX and FLK are structurally excluded from the metadata insertion path.
+
+## Approved backfill fields
+
+The live plan contains only:
+
+- 32 `base_model_code` corrections
+  - 2 F2K
+  - 30 ZIM
+- 47 `category_name` normalisations for W21
+
+The executor rejects any plan containing a backfill field outside:
+
+- `base_model_code`
+- `category_name`
+
+Every update uses a compare-and-swap guard. The row ID, file path and planned old value must still match the database before the new value is written.
+
+## Relocation policy
+
+No relocation is applied in Phase 8.9e.
+
+The three same-family candidates also cross category boundaries:
+
+- Z-Image Action to Body, currently `UNK-ACT-064`
+- two WAN2.2 Action to Body rows, currently `W22-ACT-214` and `W22-ACT-215`
+
+Preserving these IDs would retain misleading family/category prefixes. Reassigning the IDs would break stable-ID continuity. They therefore remain a separate manual policy decision alongside the 20 WAN2.2 to WAN2.1 candidates.
+
+## Safety controls
+
+Apply mode requires all of the following:
+
+1. A Phase 8.9d plan with no unresolved relocation, stable-ID exhaustion or existing-ID issues.
+2. The exact SHA-256 digest of the canonical plan JSON.
+3. An explicit `--apply` flag.
+4. An explicit backup directory.
+5. A successful SQLite backup before the write transaction begins.
+6. The expected `lora` table schema, without creating or changing columns.
+7. A `BEGIN IMMEDIATE` transaction.
+8. Compare-and-swap validation for every backfill and existing ID assignment.
+9. Stable-ID collision checks for every inserted or assigned ID.
+10. A rollback on any mismatch or error.
+
+The executor never:
+
+- invokes `lora_indexer`
+- opens safetensors tensors
+- inserts FLX/FLK records through the metadata path
+- changes scanner or orchestration maths
+- updates relocation rows
+- deletes stale or legacy rows
+- modifies the database schema
+
+New metadata rows are inserted with:
+
+- no block layout
+- no block-weight rows
+- `has_block_weights = 0`
+- `clip_tensor_count = -1` to preserve the existing unknown/backfill sentinel
+- database file paths rooted at `/loras`
+
+## Dry-run on Nibbler
+
+After Phase 8.9e is reviewed and merged, dry-run only:
+
+```bash
+cd /home/clink/docker/lora_builder/app/LoRA_weights_builder/Database/backend
+
+python3 phase89e_metadata_reconcile.py \
+  --plan /home/clink/docker/lora_builder/data/phase89d_index_plan.json \
+  --root /home/clink/docker/lora_builder/mounts/loras \
+  --db /home/clink/docker/lora_builder/data/lora_master.db \
+  --db-path-root /loras
+```
+
+This prints the plan digest and filtered execution counts. It makes no changes.
+
+## Apply command
+
+The apply command is deliberately documented but must not be run until the dry-run digest and counts are reviewed and explicit approval is given:
+
+```bash
+python3 phase89e_metadata_reconcile.py \
+  --plan /home/clink/docker/lora_builder/data/phase89d_index_plan.json \
+  --root /home/clink/docker/lora_builder/mounts/loras \
+  --db /home/clink/docker/lora_builder/data/lora_master.db \
+  --db-path-root /loras \
+  --backup-dir /home/clink/docker/lora_builder/data/backups \
+  --expected-plan-sha256 <REVIEWED_DIGEST> \
+  --apply
+```
+
+## Validation on Bender
+
+From the repository root:
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89e_metadata_reconcile.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89e_metadata_reconcile.py
+```


### PR DESCRIPTION
## What changed

- Added a guarded Phase 8.9e metadata reconciler with dry-run as the default mode.
- Consumes the exact Phase 8.9d JSON plan and requires its canonical SHA-256 before apply mode can run.
- Creates a SQLite backup before beginning the write transaction.
- Applies only approved metadata-only inserts, approved metadata backfills and the two existing missing stable IDs.
- Excludes all FLX/FLK inserts, all relocation candidates, all stale rows and all legacy/unmounted rows.
- Added stable-ID/base-code prefix protection so rows such as `UNK-...` are not silently relabelled as `ZIM`.
- Added transaction rollback, compare-and-swap row guards, stable-ID collision checks and focused tests.
- Added a complete Phase 8.9e safety/runbook document.

## Live plan boundary

The Phase 8.9d live plan reported 311 insert candidates, 79 backfills, 2 existing missing IDs, 23 relocations, 668 stale rows and 114 legacy rows.

Before the prefix guard is evaluated, this executor permits:

- 308 metadata-only insert candidates
- up to 79 metadata backfills
- 2 existing stable-ID assignments

It structurally excludes:

- 3 FLX insert candidates
- all 23 relocations
- 668 stale rows
- 114 legacy/unmounted rows

The tests include an `UNK-BDY-...` Z-Image row and verify that its proposed `ZIM` backfill is excluded rather than applied.

## Apply safeguards

Apply mode requires:

- `--apply`
- the exact reviewed `--expected-plan-sha256`
- an explicit backup directory
- a successful SQLite backup
- the expected existing schema
- compare-and-swap validation for each backfill
- stable-ID collision checks
- a single `BEGIN IMMEDIATE` transaction with rollback on any failure

## Safety

- No indexer invocation.
- No safetensors tensor access.
- No schema change.
- No scanner or orchestration maths change.
- No relocation update.
- No stale or legacy deletion.
- No database action occurs merely by merging or importing this module.

## Validation

Verified on Bender from the repository root:

```text
4 passed in 0.12s
python -m py_compile: passed silently
```
