### PR TITLE
Phase 8.9f: verify metadata reconciliation against backup

### DIFF
--- a/Database/backend/phase89f_post_apply_verify.py
+++ b/Database/backend/phase89f_post_apply_verify.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+from phase89e_metadata_reconcile import build_execution_preview, load_plan
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def _open_read_only(path: str | os.PathLike[str]) -> sqlite3.Connection:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    uri_path = quote(resolved.as_posix(), safe="/:")
+    conn = sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def _normalise(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _db_file_path(db_root: str, relative: str) -> str:
+    root = str(db_root or "").replace("\\", "/").rstrip("/")
+    rel = PurePosixPath(relative).as_posix().lstrip("/")
+    return f"{root}/{rel}" if root else rel
+
+
+def _integrity_check(conn: sqlite3.Connection, label: str) -> str:
+    row = conn.execute("PRAGMA integrity_check").fetchone()
+    result = str(row[0] if row else "")
+    if result.lower() != "ok":
+        raise VerificationError(f"{label} integrity_check failed: {result or 'no result'}")
+    return result
+
+
+def _row_by_id(conn: sqlite3.Connection, row_id: int) -> sqlite3.Row:
+    row = conn.execute("SELECT * FROM lora WHERE id = ?", (row_id,)).fetchone()
+    if row is None:
+        raise VerificationError(f"Expected lora row is missing: {row_id}")
+    return row
+
+
+def _assert_equal(actual: Any, expected: Any, message: str) -> None:
+    if actual != expected:
+        raise VerificationError(f"{message}: expected {expected!r}, found {actual!r}")
+
+
+def verify_post_apply(
+    *,
+    plan_path: str | os.PathLike[str],
+    current_db_path: str | os.PathLike[str],
+    backup_db_path: str | os.PathLike[str],
+    db_path_root: str = "/loras",
+) -> dict[str, Any]:
+    plan = load_plan(plan_path)
+    preview = build_execution_preview(plan)
+
+    current = _open_read_only(current_db_path)
+    backup = _open_read_only(backup_db_path)
+    try:
+        _integrity_check(current, "current DB")
+        _integrity_check(backup, "backup DB")
+
+        current_count = int(current.execute("SELECT COUNT(1) FROM lora").fetchone()[0])
+        backup_count = int(backup.execute("SELECT COUNT(1) FROM lora").fetchone()[0])
+        expected_delta = len(preview.inserts)
+        _assert_equal(current_count - backup_count, expected_delta, "lora row-count delta")
+
+        backup_ids = {int(row[0]) for row in backup.execute("SELECT id FROM lora")}
+        current_ids = {int(row[0]) for row in current.execute("SELECT id FROM lora")}
+        missing_ids = sorted(backup_ids - current_ids)
+        if missing_ids:
+            raise VerificationError(f"Original DB rows were deleted: {missing_ids[:20]}")
+
+        verified_inserts = 0
+        for item in preview.inserts:
+            stable_id = str(item["planned_stable_id"]).upper()
+            relative = str(item["relative_path"])
+            expected_path = _db_file_path(db_path_root, relative)
+            row = current.execute("SELECT * FROM lora WHERE stable_id = ?", (stable_id,)).fetchone()
+            if row is None:
+                raise VerificationError(f"Inserted row is missing: {stable_id}")
+            if backup.execute("SELECT 1 FROM lora WHERE stable_id = ?", (stable_id,)).fetchone() is not None:
+                raise VerificationError(f"Inserted stable ID already existed in backup: {stable_id}")
+            _assert_equal(row["file_path"], expected_path, f"insert {stable_id} file_path")
+            _assert_equal(row["filename"], item.get("filename") or PurePosixPath(relative).name, f"insert {stable_id} filename")
+            _assert_equal(row["base_model_code"], str(item.get("base_model_code") or "").upper(), f"insert {stable_id} base_model_code")
+            _assert_equal(row["category_code"], str(item.get("category_code") or "").upper(), f"insert {stable_id} category_code")
+            _assert_equal(int(row["has_block_weights"] or 0), 0, f"insert {stable_id} has_block_weights")
+            _assert_equal(row["block_layout"], None, f"insert {stable_id} block_layout")
+            _assert_equal(int(row["clip_tensor_count"]), -1, f"insert {stable_id} clip_tensor_count")
+            if current.execute("SELECT 1 FROM lora_block_weights WHERE lora_id = ?", (row["id"],)).fetchone() is not None:
+                raise VerificationError(f"Metadata-only insert unexpectedly has block rows: {stable_id}")
+            verified_inserts += 1
+
+        verified_backfills = 0
+        for item in preview.backfills:
+            row_id = int(item["row_id"])
+            before = _row_by_id(backup, row_id)
+            after = _row_by_id(current, row_id)
+            _assert_equal(after["file_path"], before["file_path"], f"backfill row {row_id} file_path")
+            for field, transition in (item.get("changed_fields") or {}).items():
+                _assert_equal(before[field], transition.get("from"), f"backfill row {row_id} backup {field}")
+                _assert_equal(after[field], transition.get("to"), f"backfill row {row_id} current {field}")
+            verified_backfills += 1
+
+        verified_ids = 0
+        for item in preview.id_assignments:
+            row_id = int(item["row_id"])
+            before = _row_by_id(backup, row_id)
+            after = _row_by_id(current, row_id)
+            if _normalise(before["stable_id"]):
+                raise VerificationError(f"Backup row {row_id} already had stable_id {before['stable_id']}")
+            _assert_equal(after["stable_id"], str(item["planned_stable_id"]).upper(), f"row {row_id} stable_id")
+            verified_ids += 1
+
+        verified_excluded_prefix = 0
+        for item in preview.excluded_id_prefix_backfills:
+            row_id = int(item["row_id"])
+            before = _row_by_id(backup, row_id)
+            after = _row_by_id(current, row_id)
+            for field in ("file_path", "base_model_code", "category_name", "category_code", "stable_id"):
+                _assert_equal(after[field], before[field], f"excluded prefix row {row_id} {field}")
+            verified_excluded_prefix += 1
+
+        relocation_items = [
+            *(plan.get("same_family_relocations") or []),
+            *(plan.get("cross_family_reclassifications") or []),
+        ]
+        verified_relocations = 0
+        for item in relocation_items:
+            row_id = int(item["row_id"])
+            before = _row_by_id(backup, row_id)
+            after = _row_by_id(current, row_id)
+            for field in ("file_path", "base_model_name", "base_model_code", "category_name", "category_code", "stable_id"):
+                _assert_equal(after[field], before[field], f"excluded relocation row {row_id} {field}")
+            verified_relocations += 1
+
+        duplicate_stable_ids = [
+            dict(row)
+            for row in current.execute(
+                """
+                SELECT stable_id, COUNT(1) AS count
+                FROM lora
+                WHERE stable_id IS NOT NULL AND TRIM(stable_id) <> ''
+                GROUP BY stable_id
+                HAVING COUNT(1) > 1
+                ORDER BY stable_id
+                """
+            )
+        ]
+        if duplicate_stable_ids:
+            raise VerificationError(f"Duplicate stable IDs detected: {duplicate_stable_ids[:20]}")
+
+        backup_block_rows = int(backup.execute("SELECT COUNT(1) FROM lora_block_weights").fetchone()[0])
+        current_block_rows = int(current.execute("SELECT COUNT(1) FROM lora_block_weights").fetchone()[0])
+        _assert_equal(current_block_rows, backup_block_rows, "lora_block_weights row count")
+
+        return {
+            "status": "verified",
+            "plan_sha256": preview.plan_sha256,
+            "backup_lora_rows": backup_count,
+            "current_lora_rows": current_count,
+            "row_delta": current_count - backup_count,
+            "verified_metadata_inserts": verified_inserts,
+            "verified_metadata_backfills": verified_backfills,
+            "verified_existing_id_assignments": verified_ids,
+            "verified_excluded_id_prefix_backfills": verified_excluded_prefix,
+            "verified_excluded_relocations": verified_relocations,
+            "duplicate_stable_ids": 0,
+            "block_weight_row_delta": current_block_rows - backup_block_rows,
+            "untouched_stale_rows_declared": preview.untouched_stale_rows,
+            "untouched_legacy_rows_declared": preview.untouched_legacy_rows,
+        }
+    finally:
+        current.close()
+        backup.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify a Phase 8.9e apply against its backup and plan")
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--backup", required=True)
+    parser.add_argument("--db-path-root", default="/loras")
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    result = verify_post_apply(
+        plan_path=args.plan,
+        current_db_path=args.db,
+        backup_db_path=args.backup,
+        db_path_root=args.db_path_root,
+    )
+    print("=== Phase 8.9f post-apply verification ===")
+    for key, value in result.items():
+        print(f"{key}: {value}")
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"JSON verification written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/phase89f_post_apply_verify.py
+++ b/Database/backend/phase89f_post_apply_verify.py
@@ -72,14 +72,15 @@ def verify_post_apply(
 
         current_count = int(current.execute("SELECT COUNT(1) FROM lora").fetchone()[0])
         backup_count = int(backup.execute("SELECT COUNT(1) FROM lora").fetchone()[0])
-        expected_delta = len(preview.inserts)
-        _assert_equal(current_count - backup_count, expected_delta, "lora row-count delta")
 
         backup_ids = {int(row[0]) for row in backup.execute("SELECT id FROM lora")}
         current_ids = {int(row[0]) for row in current.execute("SELECT id FROM lora")}
         missing_ids = sorted(backup_ids - current_ids)
         if missing_ids:
             raise VerificationError(f"Original DB rows were deleted: {missing_ids[:20]}")
+
+        expected_delta = len(preview.inserts)
+        _assert_equal(current_count - backup_count, expected_delta, "lora row-count delta")
 
         verified_inserts = 0
         for item in preview.inserts:

--- a/Database/backend/tests/test_phase89f_post_apply_verify.py
+++ b/Database/backend/tests/test_phase89f_post_apply_verify.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import sys
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from phase89e_metadata_reconcile import apply_preview, build_execution_preview  # noqa: E402
+from phase89f_post_apply_verify import VerificationError, verify_post_apply  # noqa: E402
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"test")
+
+
+def _create_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            filename TEXT NOT NULL,
+            base_model_name TEXT,
+            base_model_code TEXT,
+            category_name TEXT,
+            category_code TEXT,
+            model_family TEXT,
+            lora_type TEXT,
+            rank INTEGER,
+            has_block_weights INTEGER NOT NULL DEFAULT 0,
+            block_layout TEXT,
+            clip_contributor INTEGER NOT NULL DEFAULT 0,
+            clip_tensor_count INTEGER NOT NULL DEFAULT -1,
+            last_modified REAL NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            stable_id TEXT
+        );
+        CREATE TABLE lora_block_weights (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lora_id INTEGER NOT NULL,
+            stable_id TEXT,
+            block_index INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            raw_strength REAL
+        );
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO lora (
+            id, file_path, filename,
+            base_model_name, base_model_code,
+            category_name, category_code,
+            model_family, lora_type, rank,
+            has_block_weights, block_layout,
+            clip_contributor, clip_tensor_count,
+            last_modified, created_at, updated_at, stable_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                1,
+                "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "existing-klein.safetensors",
+                "Flux.2-Klein",
+                None,
+                "Utils",
+                "UTL",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                None,
+            ),
+            (
+                2,
+                "/loras/WAN2.1/T2V/04 - Action/existing-wan.safetensors",
+                "existing-wan.safetensors",
+                "WAN2.1",
+                "W21",
+                "04 - Action",
+                "ACT",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                "W21-ACT-001",
+            ),
+            (
+                3,
+                "/loras/Z-Image/05 - Body/excluded-zim.safetensors",
+                "excluded-zim.safetensors",
+                "Z-Image",
+                None,
+                "Body",
+                "BDY",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                "UNK-BDY-001",
+            ),
+            (
+                4,
+                "/loras/WAN2.2/I2V/04 - Action/relocated.safetensors",
+                "relocated.safetensors",
+                "WAN2.2",
+                "W22",
+                "Action",
+                "ACT",
+                None,
+                None,
+                None,
+                0,
+                None,
+                0,
+                -1,
+                1.0,
+                "2026-07-26T00:00:00+00:00",
+                "2026-07-26T00:00:00+00:00",
+                "W22-ACT-001",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _plan() -> dict:
+    return {
+        "audit_mode": "read-only",
+        "summary": {
+            "untouched_stale_current_family_rows": 10,
+            "untouched_legacy_unmounted_rows": 2,
+        },
+        "safety": {"writes_database": False, "runs_indexer": False, "assigns_stable_ids": False},
+        "unresolved_relocations": [],
+        "stable_id_groups_exhausted": [],
+        "existing_stable_id_issues": [],
+        "same_family_relocations": [
+            {
+                "row_id": 4,
+                "old_path": "/loras/WAN2.2/I2V/04 - Action/relocated.safetensors",
+                "new_path": "WAN2.2/I2V/05 - Body/relocated.safetensors",
+            }
+        ],
+        "cross_family_reclassifications": [],
+        "new_metadata_insert_candidates": [
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "Flux.2-Klein/03 - Utils/new-klein.safetensors",
+                "filename": "new-klein.safetensors",
+                "base_model_name": "Flux.2-Klein",
+                "base_model_code": "F2K",
+                "category_name": "Utils",
+                "category_code": "UTL",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "FLUX/01 - People/needs-scanner.safetensors",
+                "filename": "needs-scanner.safetensors",
+                "base_model_name": "Flux",
+                "base_model_code": "FLX",
+                "category_name": "People",
+                "category_code": "PPL",
+            },
+        ],
+        "mounted_metadata_backfill_candidates": [
+            {
+                "row_id": 1,
+                "stable_id": None,
+                "file_path": "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "parsed_base_model_code": "F2K",
+                "changed_fields": {"base_model_code": {"from": None, "to": "F2K"}},
+            },
+            {
+                "row_id": 2,
+                "stable_id": "W21-ACT-001",
+                "file_path": "/loras/WAN2.1/T2V/04 - Action/existing-wan.safetensors",
+                "parsed_base_model_code": "W21",
+                "changed_fields": {"category_name": {"from": "04 - Action", "to": "Action"}},
+            },
+            {
+                "row_id": 3,
+                "stable_id": "UNK-BDY-001",
+                "file_path": "/loras/Z-Image/05 - Body/excluded-zim.safetensors",
+                "parsed_base_model_code": "ZIM",
+                "changed_fields": {"base_model_code": {"from": None, "to": "ZIM"}},
+            },
+        ],
+        "mounted_existing_rows_missing_stable_id": [
+            {
+                "source_type": "existing_mounted_row_missing_id",
+                "row_id": 1,
+                "file_path": "/loras/Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "relative_path": "Flux.2-Klein/03 - Utils/existing-klein.safetensors",
+                "filename": "existing-klein.safetensors",
+                "base_model_code": "F2K",
+                "category_code": "UTL",
+            }
+        ],
+        "planned_stable_ids": [
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "Flux.2-Klein/03 - Utils/new-klein.safetensors",
+                "planned_stable_id": "F2K-UTL-002",
+            },
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": "FLUX/01 - People/needs-scanner.safetensors",
+                "planned_stable_id": "FLX-PPL-001",
+            },
+            {
+                "source_type": "existing_mounted_row_missing_id",
+                "row_id": 1,
+                "planned_stable_id": "F2K-UTL-001",
+            },
+        ],
+    }
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, dict]:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+    backup_dir = tmp_path / "backups"
+    plan_path = tmp_path / "plan.json"
+    _touch(root / "Flux.2-Klein" / "03 - Utils" / "new-klein.safetensors")
+    _touch(root / "FLUX" / "01 - People" / "needs-scanner.safetensors")
+    _create_db(db)
+    plan = _plan()
+    plan_path.write_text(__import__("json").dumps(plan), encoding="utf-8")
+    preview = build_execution_preview(plan)
+    result = apply_preview(
+        preview,
+        db_path=db,
+        library_root=root,
+        db_path_root="/loras",
+        backup_dir=backup_dir,
+        expected_plan_sha256=preview.plan_sha256,
+    )
+    return plan_path, db, Path(result["backup_path"]), plan
+
+
+def test_verifier_confirms_exact_apply_scope(tmp_path: Path) -> None:
+    plan_path, db, backup, _ = _fixture(tmp_path)
+
+    result = verify_post_apply(
+        plan_path=plan_path,
+        current_db_path=db,
+        backup_db_path=backup,
+        db_path_root="/loras",
+    )
+
+    assert result["status"] == "verified"
+    assert result["row_delta"] == 1
+    assert result["verified_metadata_inserts"] == 1
+    assert result["verified_metadata_backfills"] == 2
+    assert result["verified_existing_id_assignments"] == 1
+    assert result["verified_excluded_id_prefix_backfills"] == 1
+    assert result["verified_excluded_relocations"] == 1
+    assert result["duplicate_stable_ids"] == 0
+    assert result["block_weight_row_delta"] == 0
+
+
+def test_verifier_detects_change_to_excluded_relocation(tmp_path: Path) -> None:
+    plan_path, db, backup, _ = _fixture(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE lora SET category_name = 'Body' WHERE id = 4")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(VerificationError, match="excluded relocation row 4 category_name"):
+        verify_post_apply(
+            plan_path=plan_path,
+            current_db_path=db,
+            backup_db_path=backup,
+            db_path_root="/loras",
+        )
+
+
+def test_verifier_detects_deleted_original_row(tmp_path: Path) -> None:
+    plan_path, db, backup, _ = _fixture(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("DELETE FROM lora WHERE id = 4")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(VerificationError, match="Original DB rows were deleted"):
+        verify_post_apply(
+            plan_path=plan_path,
+            current_db_path=db,
+            backup_db_path=backup,
+            db_path_root="/loras",
+        )

--- a/docs/phase89f-post-apply-verification.md
+++ b/docs/phase89f-post-apply-verification.md
@@ -1,0 +1,77 @@
+# Phase 8.9f post-apply verification
+
+Phase 8.9f verifies the completed Phase 8.9e metadata reconciliation by comparing three fixed inputs:
+
+1. The reviewed Phase 8.9d JSON plan.
+2. The SQLite backup created immediately before Phase 8.9e.
+3. The current SQLite database after Phase 8.9e.
+
+The verifier is strictly read-only. Both SQLite files are opened with URI `mode=ro` and `PRAGMA query_only = ON`.
+
+## Live execution being verified
+
+The reported Phase 8.9e execution was:
+
+```text
+backup_path: /home/clink/docker/lora_builder/data/backups/lora_master.phase89e.20260726T182850Z.e93d23901e4f.db
+metadata_inserts: 308
+metadata_backfills: 49
+existing_id_assignments: 2
+excluded_scanned_inserts: 3
+excluded_id_prefix_backfills: 30
+excluded_relocations: 23
+```
+
+The plan digest was:
+
+```text
+e93d23901e4f05b0f250a0574c8662700be3428854c104f62146058e7ba6c7f2
+```
+
+## Verification coverage
+
+The verifier confirms:
+
+- `PRAGMA integrity_check` returns `ok` for both backup and current databases.
+- Current `lora` row count equals backup count plus the approved metadata inserts.
+- Every row ID present in the backup still exists in the current database.
+- Every approved metadata insert exists with its planned stable ID, file path, base/category codes and metadata-only state.
+- No approved metadata insert has block-weight rows.
+- Every approved backfill changed from the exact planned old value to the exact planned new value.
+- Every approved existing-row stable-ID assignment was empty in the backup and equals the planned ID in the current database.
+- Every excluded ID-prefix backfill remains unchanged across identity and category fields.
+- Every same-family and cross-family relocation row remains unchanged across path, family, category and stable-ID fields.
+- No duplicate non-empty stable IDs exist.
+- `lora_block_weights` row count is unchanged.
+
+The verifier does not modify either database, regenerate the plan, run the indexer or open safetensors files.
+
+## Validation on Bender
+
+From the repository root:
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89f_post_apply_verify.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89f_post_apply_verify.py
+```
+
+## Live verification on Nibbler
+
+After review and merge:
+
+```bash
+cd /home/clink/docker/lora_builder/app/LoRA_weights_builder/Database/backend
+
+python3 phase89f_post_apply_verify.py \
+  --plan /home/clink/docker/lora_builder/data/phase89d_index_plan.json \
+  --db /home/clink/docker/lora_builder/data/lora_master.db \
+  --backup /home/clink/docker/lora_builder/data/backups/lora_master.phase89e.20260726T182850Z.e93d23901e4f.db \
+  --db-path-root /loras \
+  --json /home/clink/docker/lora_builder/data/phase89f_post_apply_verification.json
+```
+
+A successful run reports `status: verified`. Any mismatch raises an error and exits without changing data.


### PR DESCRIPTION
## What changed

- Added a read-only Phase 8.9f verifier for the completed Phase 8.9e reconciliation.
- Compares the reviewed Phase 8.9d plan, the pre-write SQLite backup and the current SQLite database.
- Verifies both approved changes and excluded rows.
- Added focused tests and an operational runbook.

## Verification coverage

The verifier checks:

- `PRAGMA integrity_check` on backup and current DBs.
- No original row IDs were deleted.
- Current row count equals backup row count plus the approved insert count.
- All approved metadata inserts match planned stable IDs, paths, family/category codes and metadata-only state.
- No inserted metadata row has block weights.
- All approved backfills moved from the planned old value to the planned new value.
- Both existing-row stable-ID assignments match the plan.
- All 30 excluded ID-prefix backfills remain unchanged.
- All 23 relocation rows remain unchanged across path, family, category and stable-ID fields.
- Non-empty stable IDs remain unique.
- `lora_block_weights` row count is unchanged.

## Live execution under verification

```text
backup_path: /home/clink/docker/lora_builder/data/backups/lora_master.phase89e.20260726T182850Z.e93d23901e4f.db
metadata_inserts: 308
metadata_backfills: 49
existing_id_assignments: 2
excluded_scanned_inserts: 3
excluded_id_prefix_backfills: 30
excluded_relocations: 23
```

## Safety

- Both DBs are opened with SQLite URI `mode=ro`.
- `PRAGMA query_only = ON` is enabled.
- No indexer or safetensors operation runs.
- No database, plan or backup file is modified.

## Validation

Verified on Bender from the repository root:

```text
3 passed in 0.15s
python -m py_compile: passed silently
```

The deletion-detection test now reports the specific deleted-row condition before the aggregate row-count mismatch.