### PR TITLE
Phase 8.9g: add targeted read-only Flux analysis

### DIFF
--- a/Database/backend/phase89g_targeted_flux_analysis.py
+++ b/Database/backend/phase89g_targeted_flux_analysis.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Mapping
+from urllib.parse import quote
+
+
+class FluxAnalysisPlanError(RuntimeError):
+    pass
+
+
+Analyzer = Callable[[Path, str], Mapping[str, Any]]
+TensorReader = Callable[[Path], tuple[bool, int, int]]
+LayoutResolver = Callable[[str | None, int], str | None]
+
+
+def load_plan(path: str | os.PathLike[str]) -> dict[str, Any]:
+    plan_path = Path(path).expanduser().resolve(strict=True)
+    with plan_path.open("r", encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise FluxAnalysisPlanError("Plan JSON must contain an object at the top level")
+    return plan
+
+
+def canonical_plan_bytes(plan: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plan,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def plan_sha256(plan: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_plan_bytes(plan)).hexdigest()
+
+
+def _normalise_code(value: Any) -> str:
+    return str(value or "").strip().upper()
+
+
+def _open_read_only(path: str | os.PathLike[str]) -> sqlite3.Connection:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    uri_path = quote(resolved.as_posix(), safe="/:")
+    conn = sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def _db_file_path(db_root: str, relative: str) -> str:
+    root = str(db_root or "").replace("\\", "/").rstrip("/")
+    rel = PurePosixPath(relative).as_posix().lstrip("/")
+    return f"{root}/{rel}" if root else rel
+
+
+def _planned_insert_ids(plan: Mapping[str, Any]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw in plan.get("planned_stable_ids", []):
+        if not isinstance(raw, Mapping):
+            continue
+        if str(raw.get("source_type") or "") != "new_metadata_insert":
+            continue
+        relative = str(raw.get("relative_path") or "").strip()
+        stable_id = str(raw.get("planned_stable_id") or "").strip().upper()
+        if not relative or not stable_id:
+            continue
+        key = PurePosixPath(relative).as_posix().casefold()
+        if key in result and result[key] != stable_id:
+            raise FluxAnalysisPlanError(
+                f"Plan contains conflicting stable IDs for {relative}"
+            )
+        result[key] = stable_id
+    return result
+
+
+def _safe_source_path(root: Path, relative: str) -> Path:
+    pure = PurePosixPath(relative)
+    if pure.is_absolute() or ".." in pure.parts:
+        raise FluxAnalysisPlanError(f"Unsafe relative path in plan: {relative}")
+    source = root.joinpath(*pure.parts).resolve(strict=True)
+    try:
+        source.relative_to(root)
+    except ValueError as exc:
+        raise FluxAnalysisPlanError(
+            f"Plan path escapes the approved library root: {relative}"
+        ) from exc
+    if not source.is_file() or source.suffix.casefold() != ".safetensors":
+        raise FluxAnalysisPlanError(f"Flux target is not a safetensors file: {source}")
+    return source
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def default_tensor_reader(path: Path) -> tuple[bool, int, int]:
+    from clip_contribution import is_clip_contributor
+    from safetensors import safe_open
+
+    with safe_open(str(path), framework="pt") as safetensors_file:
+        tensor_keys = list(safetensors_file.keys())
+    clip_contributor, clip_tensor_count = is_clip_contributor(tensor_keys)
+    return bool(clip_contributor), int(clip_tensor_count), len(tensor_keys)
+
+
+def default_analyzer(path: Path, base_model_code: str) -> Mapping[str, Any]:
+    from delta_inspector_engine import inspect_lora
+
+    return inspect_lora(str(path), base_model_code=base_model_code)
+
+
+def default_layout_resolver(lora_type: str | None, block_count: int) -> str | None:
+    from block_layouts import (
+        FLUX_FALLBACK_16,
+        make_flux_layout,
+        normalize_block_layout,
+    )
+
+    if block_count <= 0:
+        return FLUX_FALLBACK_16
+
+    layout = normalize_block_layout(make_flux_layout(lora_type, block_count))
+    if layout is None:
+        layout = normalize_block_layout(f"flux_transformer_{block_count}")
+    return layout
+
+
+def build_flux_analysis_plan(
+    plan: Mapping[str, Any],
+    *,
+    library_root: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    db_path_root: str = "/loras",
+    expected_count: int = 3,
+    analyzer: Analyzer | None = None,
+    tensor_reader: TensorReader | None = None,
+    layout_resolver: LayoutResolver | None = None,
+) -> dict[str, Any]:
+    if plan.get("audit_mode") != "read-only":
+        raise FluxAnalysisPlanError(
+            "Phase 8.9g accepts only a Phase 8.9d read-only plan"
+        )
+
+    safety = plan.get("safety") or {}
+    if safety.get("writes_database") is not False:
+        raise FluxAnalysisPlanError(
+            "Plan safety flags do not describe a read-only planner run"
+        )
+
+    blockers = {
+        "unresolved_relocations": plan.get("unresolved_relocations") or [],
+        "stable_id_groups_exhausted": plan.get("stable_id_groups_exhausted") or [],
+        "existing_stable_id_issues": plan.get("existing_stable_id_issues") or [],
+    }
+    active_blockers = [name for name, values in blockers.items() if values]
+    if active_blockers:
+        raise FluxAnalysisPlanError(
+            "Plan has unresolved blockers: " + ", ".join(sorted(active_blockers))
+        )
+
+    candidates = [
+        dict(raw)
+        for raw in plan.get("new_metadata_insert_candidates", [])
+        if isinstance(raw, Mapping)
+        and _normalise_code(raw.get("base_model_code")) == "FLX"
+    ]
+    if len(candidates) != int(expected_count):
+        raise FluxAnalysisPlanError(
+            f"Expected exactly {expected_count} FLX candidates, found {len(candidates)}"
+        )
+
+    ids = _planned_insert_ids(plan)
+    root = Path(library_root).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise FluxAnalysisPlanError(f"Library root is not a directory: {root}")
+
+    analyzer_fn = analyzer or default_analyzer
+    tensor_reader_fn = tensor_reader or default_tensor_reader
+    layout_resolver_fn = layout_resolver or default_layout_resolver
+
+    conn = _open_read_only(db_path)
+    try:
+        integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
+        if integrity.casefold() != "ok":
+            raise FluxAnalysisPlanError(
+                f"Database integrity check failed: {integrity}"
+            )
+
+        results: list[dict[str, Any]] = []
+        for candidate in sorted(
+            candidates,
+            key=lambda item: str(item.get("relative_path") or "").casefold(),
+        ):
+            if str(candidate.get("source_type") or "") != "new_metadata_insert":
+                raise FluxAnalysisPlanError(
+                    "FLX candidate is not marked as new_metadata_insert"
+                )
+
+            relative = PurePosixPath(
+                str(candidate.get("relative_path") or "")
+            ).as_posix()
+            if not relative or relative == ".":
+                raise FluxAnalysisPlanError(
+                    "FLX candidate is missing relative_path"
+                )
+
+            category_code = _normalise_code(candidate.get("category_code"))
+            if not category_code:
+                raise FluxAnalysisPlanError(
+                    f"FLX candidate has no category code: {relative}"
+                )
+
+            stable_id = ids.get(relative.casefold())
+            if not stable_id:
+                raise FluxAnalysisPlanError(
+                    f"No planned stable ID for FLX candidate: {relative}"
+                )
+            expected_prefix = f"FLX-{category_code}-"
+            if not stable_id.startswith(expected_prefix):
+                raise FluxAnalysisPlanError(
+                    f"Planned stable ID {stable_id} does not match {expected_prefix} for {relative}"
+                )
+
+            source = _safe_source_path(root, relative)
+            db_file_path = _db_file_path(db_path_root, relative)
+
+            existing_path = conn.execute(
+                "SELECT id, stable_id FROM lora WHERE file_path = ?",
+                (db_file_path,),
+            ).fetchone()
+            if existing_path is not None:
+                raise FluxAnalysisPlanError(
+                    f"Target file_path already exists in DB: {db_file_path}"
+                )
+
+            existing_id = conn.execute(
+                "SELECT id, file_path FROM lora WHERE stable_id = ?",
+                (stable_id,),
+            ).fetchone()
+            if existing_id is not None:
+                raise FluxAnalysisPlanError(
+                    f"Planned stable ID already exists in DB: {stable_id}"
+                )
+
+            clip_contributor, clip_tensor_count, tensor_key_count = tensor_reader_fn(
+                source
+            )
+            analysis = dict(analyzer_fn(source, "FLX"))
+            block_weights = [
+                float(value) for value in (analysis.get("block_weights") or [])
+            ]
+            raw_strengths = [
+                float(value)
+                for value in (analysis.get("raw_block_strengths") or [])
+            ]
+            block_layout = layout_resolver_fn(
+                analysis.get("lora_type"),
+                len(block_weights),
+            )
+
+            warnings: list[str] = []
+            if block_weights and block_layout is None:
+                warnings.append(
+                    f"No supported block layout for {len(block_weights)} analysed blocks"
+                )
+            if raw_strengths and len(raw_strengths) != len(block_weights):
+                warnings.append(
+                    "raw_block_strengths count does not match block_weights count"
+                )
+
+            ready = not warnings
+            result = {
+                "relative_path": relative,
+                "db_file_path": db_file_path,
+                "filename": candidate.get("filename") or source.name,
+                "planned_stable_id": stable_id,
+                "base_model_name": candidate.get("base_model_name"),
+                "base_model_code": "FLX",
+                "category_name": candidate.get("category_name"),
+                "category_code": category_code,
+                "source_size_bytes": source.stat().st_size,
+                "source_mtime": source.stat().st_mtime,
+                "source_sha256": _sha256_file(source),
+                "tensor_key_count": int(tensor_key_count),
+                "clip_contributor": bool(clip_contributor),
+                "clip_tensor_count": int(clip_tensor_count),
+                "model_family": analysis.get("model_family"),
+                "lora_type": analysis.get("lora_type"),
+                "rank": analysis.get("rank"),
+                "has_block_weights": bool(block_weights),
+                "block_count": len(block_weights),
+                "raw_strength_count": len(raw_strengths),
+                "block_layout": block_layout,
+                "block_weight_min": min(block_weights) if block_weights else None,
+                "block_weight_max": max(block_weights) if block_weights else None,
+                "block_weight_mean": (
+                    sum(block_weights) / len(block_weights)
+                    if block_weights
+                    else None
+                ),
+                "warnings": warnings,
+                "ready_for_controlled_apply": ready,
+            }
+            results.append(result)
+
+        ready_count = sum(
+            1 for result in results if result["ready_for_controlled_apply"]
+        )
+        return {
+            "phase": "8.9g",
+            "mode": "read-only targeted FLX analysis",
+            "plan_sha256": plan_sha256(plan),
+            "summary": {
+                "flux_candidates": len(results),
+                "ready_for_controlled_apply": ready_count,
+                "blocked_candidates": len(results) - ready_count,
+                "total_analysed_block_rows": sum(
+                    int(result["block_count"]) for result in results
+                ),
+            },
+            "targets": results,
+            "safety": {
+                "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+                "writes_database": False,
+                "runs_full_indexer": False,
+                "discovers_library_files": False,
+                "opens_only_plan_listed_safetensors": True,
+                "assigns_stable_ids": False,
+                "deletes_rows": False,
+            },
+        }
+    finally:
+        conn.close()
+
+
+def print_analysis_plan(result: Mapping[str, Any]) -> None:
+    summary = result["summary"]
+    print("=== Phase 8.9g targeted FLX analysis ===")
+    print(f"Mode                       : {result['mode']}")
+    print(f"Plan SHA-256               : {result['plan_sha256']}")
+    print(f"FLX candidates             : {summary['flux_candidates']}")
+    print(
+        "Ready for controlled apply : "
+        f"{summary['ready_for_controlled_apply']}"
+    )
+    print(f"Blocked candidates         : {summary['blocked_candidates']}")
+    print(
+        "Total analysed block rows  : "
+        f"{summary['total_analysed_block_rows']}"
+    )
+    print()
+    for target in result["targets"]:
+        print(target["relative_path"])
+        print(f"  stable_id       : {target['planned_stable_id']}")
+        print(f"  sha256          : {target['source_sha256']}")
+        print(
+            "  analysis        : "
+            f"family={target['model_family']!r}, "
+            f"type={target['lora_type']!r}, rank={target['rank']!r}"
+        )
+        print(
+            "  blocks          : "
+            f"{target['block_count']} ({target['block_layout']})"
+        )
+        print(
+            "  clip            : "
+            f"{target['clip_contributor']} "
+            f"({target['clip_tensor_count']} tensors)"
+        )
+        print(
+            "  controlled apply: "
+            f"{target['ready_for_controlled_apply']}"
+        )
+        for warning in target["warnings"]:
+            print(f"  warning         : {warning}")
+    print()
+    print("No database changes were made.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only analysis of the exact FLX insert candidates held out "
+            "of the Phase 8.9e metadata reconciliation"
+        )
+    )
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--db-path-root", default="/loras")
+    parser.add_argument("--expected-count", type=int, default=3)
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    plan = load_plan(args.plan)
+    result = build_flux_analysis_plan(
+        plan,
+        library_root=args.root,
+        db_path=args.db,
+        db_path_root=args.db_path_root,
+        expected_count=args.expected_count,
+    )
+    print_analysis_plan(result)
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        print(f"JSON analysis written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/tests/test_phase89g_targeted_flux_analysis.py
+++ b/Database/backend/tests/test_phase89g_targeted_flux_analysis.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import sqlite3
+import sys
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from phase89g_targeted_flux_analysis import (  # noqa: E402
+    FluxAnalysisPlanError,
+    build_flux_analysis_plan,
+)
+
+
+def _create_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            stable_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _touch(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _candidate(relative: str, stable_id: str, category_code: str) -> tuple[dict, dict]:
+    filename = Path(relative).name
+    item = {
+        "source_type": "new_metadata_insert",
+        "relative_path": relative,
+        "filename": filename,
+        "base_model_name": "Flux",
+        "base_model_code": "FLX",
+        "category_name": {
+            "PPL": "People",
+            "STL": "Styles",
+            "UTL": "Utils",
+        }[category_code],
+        "category_code": category_code,
+    }
+    planned = {
+        "source_type": "new_metadata_insert",
+        "relative_path": relative,
+        "planned_stable_id": stable_id,
+    }
+    return item, planned
+
+
+def _plan() -> dict:
+    pairs = [
+        _candidate(
+            "FLUX/01 - People/alpha.safetensors",
+            "FLX-PPL-101",
+            "PPL",
+        ),
+        _candidate(
+            "FLUX/02 - Styles/beta.safetensors",
+            "FLX-STL-102",
+            "STL",
+        ),
+        _candidate(
+            "FLUX/03 - Utils/gamma.safetensors",
+            "FLX-UTL-103",
+            "UTL",
+        ),
+    ]
+    return {
+        "audit_mode": "read-only",
+        "safety": {
+            "writes_database": False,
+            "runs_indexer": False,
+        },
+        "unresolved_relocations": [],
+        "stable_id_groups_exhausted": [],
+        "existing_stable_id_issues": [],
+        "new_metadata_insert_candidates": [pair[0] for pair in pairs],
+        "planned_stable_ids": [pair[1] for pair in pairs],
+    }
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+    _touch(root / "FLUX" / "01 - People" / "alpha.safetensors", b"alpha")
+    _touch(root / "FLUX" / "02 - Styles" / "beta.safetensors", b"beta")
+    _touch(root / "FLUX" / "03 - Utils" / "gamma.safetensors", b"gamma")
+    _create_db(db)
+    return root, db
+
+
+def _analyzer(path: Path, base_model_code: str) -> dict:
+    assert base_model_code == "FLX"
+    if path.name == "alpha.safetensors":
+        return {
+            "model_family": "flux",
+            "lora_type": "transformer",
+            "rank": 16,
+            "block_weights": [0.1, 0.2],
+            "raw_block_strengths": [1.0, 2.0],
+        }
+    if path.name == "beta.safetensors":
+        return {
+            "model_family": "flux",
+            "lora_type": "transformer",
+            "rank": 32,
+            "block_weights": [],
+            "raw_block_strengths": [],
+        }
+    return {
+        "model_family": "flux",
+        "lora_type": "transformer",
+        "rank": 8,
+        "block_weights": [0.3],
+        "raw_block_strengths": [3.0],
+    }
+
+
+def _tensor_reader(path: Path) -> tuple[bool, int, int]:
+    return path.name != "beta.safetensors", 2, 10
+
+
+def _layout_resolver(_lora_type: str | None, count: int) -> str | None:
+    return "flux_fallback_16" if count == 0 else f"flux_transformer_{count}"
+
+
+def test_read_only_plan_analyses_only_three_flux_targets(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+    before = hashlib.sha256(db.read_bytes()).hexdigest()
+
+    result = build_flux_analysis_plan(
+        _plan(),
+        library_root=root,
+        db_path=db,
+        analyzer=_analyzer,
+        tensor_reader=_tensor_reader,
+        layout_resolver=_layout_resolver,
+    )
+
+    after = hashlib.sha256(db.read_bytes()).hexdigest()
+    assert before == after
+    assert result["summary"] == {
+        "flux_candidates": 3,
+        "ready_for_controlled_apply": 3,
+        "blocked_candidates": 0,
+        "total_analysed_block_rows": 3,
+    }
+    assert [item["planned_stable_id"] for item in result["targets"]] == [
+        "FLX-PPL-101",
+        "FLX-STL-102",
+        "FLX-UTL-103",
+    ]
+    assert result["targets"][0]["source_sha256"] == hashlib.sha256(b"alpha").hexdigest()
+    assert result["targets"][1]["has_block_weights"] is False
+    assert result["targets"][1]["block_layout"] == "flux_fallback_16"
+    assert result["safety"]["writes_database"] is False
+    assert result["safety"]["discovers_library_files"] is False
+
+
+def test_plan_refuses_unexpected_flux_candidate_count(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+    plan = _plan()
+    plan["new_metadata_insert_candidates"].pop()
+
+    with pytest.raises(
+        FluxAnalysisPlanError,
+        match="Expected exactly 3 FLX candidates, found 2",
+    ):
+        build_flux_analysis_plan(
+            plan,
+            library_root=root,
+            db_path=db,
+            analyzer=_analyzer,
+            tensor_reader=_tensor_reader,
+            layout_resolver=_layout_resolver,
+        )
+
+
+def test_plan_refuses_existing_path_or_stable_id(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO lora (file_path, stable_id) VALUES (?, ?)",
+        ("/loras/FLUX/01 - People/alpha.safetensors", "OLD-PPL-001"),
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(
+        FluxAnalysisPlanError,
+        match="Target file_path already exists in DB",
+    ):
+        build_flux_analysis_plan(
+            _plan(),
+            library_root=root,
+            db_path=db,
+            analyzer=_analyzer,
+            tensor_reader=_tensor_reader,
+            layout_resolver=_layout_resolver,
+        )
+
+
+def test_unsupported_layout_marks_candidate_blocked(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+
+    def layout_resolver(_lora_type: str | None, count: int) -> str | None:
+        return None if count == 2 else _layout_resolver(_lora_type, count)
+
+    result = build_flux_analysis_plan(
+        _plan(),
+        library_root=root,
+        db_path=db,
+        analyzer=_analyzer,
+        tensor_reader=_tensor_reader,
+        layout_resolver=layout_resolver,
+    )
+
+    assert result["summary"]["ready_for_controlled_apply"] == 2
+    assert result["summary"]["blocked_candidates"] == 1
+    blocked = [item for item in result["targets"] if not item["ready_for_controlled_apply"]]
+    assert len(blocked) == 1
+    assert "No supported block layout" in blocked[0]["warnings"][0]

--- a/docs/phase89g-targeted-flux-analysis.md
+++ b/docs/phase89g-targeted-flux-analysis.md
@@ -1,0 +1,79 @@
+# Phase 8.9g targeted Flux analysis plan
+
+Phase 8.9g inspects only the three FLX files that were deliberately excluded from the Phase 8.9e metadata-only reconciliation.
+
+It is a read-only planning phase. It does not contain an apply mode.
+
+## Why this phase exists
+
+The general indexer discovers every `.safetensors` file beneath the configured LoRA root. That is unsuitable for the controlled Phase 8.9 workflow because it could revisit thousands of existing rows.
+
+The three excluded FLX candidates require real tensor-key inspection and the Flux delta-analysis engine. Phase 8.9g reuses those per-file analysis components without invoking the full filesystem indexer.
+
+## Scope controls
+
+The analyser consumes the reviewed Phase 8.9d JSON plan and:
+
+- selects candidates whose `base_model_code` is exactly `FLX`
+- requires exactly three candidates by default
+- accepts only `source_type = new_metadata_insert`
+- opens only the exact plan-listed relative paths
+- rejects absolute paths, `..` traversal and paths escaping the approved root
+- checks that every target is still absent from the database
+- checks that every planned stable ID remains unused
+- validates the planned stable-ID family and category prefix
+- opens SQLite with `mode=ro` and `PRAGMA query_only = ON`
+
+It does not enumerate the library and never calls `lora_indexer.main()`.
+
+## Analysis output
+
+For each target, the JSON records:
+
+- relative and database paths
+- planned stable ID
+- SHA-256 and file size
+- tensor-key count
+- CLIP contributor status and tensor count
+- analysed model family, LoRA type and rank
+- block count and resolved layout
+- block-weight minimum, maximum and mean
+- warnings and controlled-apply readiness
+
+A candidate is blocked from a later controlled apply when:
+
+- analysed blocks do not map to a supported block layout
+- raw-strength and block-weight counts disagree
+
+No database row or block-weight row is created in this phase.
+
+## Validation
+
+From the Bender repository root:
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89g_targeted_flux_analysis.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89g_targeted_flux_analysis.py
+```
+
+## Planned Nibbler run
+
+After review and merge:
+
+```bash
+cd /home/clink/docker/lora_builder/app/LoRA_weights_builder/Database/backend
+
+python3 phase89g_targeted_flux_analysis.py \
+  --plan /home/clink/docker/lora_builder/data/phase89d_index_plan.json \
+  --root /home/clink/docker/lora_builder/mounts/loras \
+  --db /home/clink/docker/lora_builder/data/lora_master.db \
+  --db-path-root /loras \
+  --expected-count 3 \
+  --json /home/clink/docker/lora_builder/data/phase89g_flux_analysis.json
+```
+
+The current database should be hashed before and after the run. Both hashes must match.


### PR DESCRIPTION
## What changed

- Added a read-only analyser for the three FLX candidates excluded from Phase 8.9e.
- Consumes the reviewed Phase 8.9d JSON plan and requires exactly three FLX candidates by default.
- Opens only the exact plan-listed safetensors paths.
- Reuses tensor-key inspection and the Flux delta-analysis engine per file without calling the full indexer.
- Checks every target path and planned stable ID against the live SQLite DB opened read-only.
- Hashes each source file and records model family, type, rank, CLIP contribution, block count, layout and summary statistics.
- Marks unsupported layouts or mismatched raw-strength counts as blocked from a later controlled apply.
- Added focused tests and an operational runbook.

## Safety boundary

- No database writes.
- No full-library discovery.
- No `lora_indexer.main()` invocation.
- No stable-ID assignment.
- No stale-row or relocation work.
- No apply mode exists in this phase.

## Validation

Verified on Bender from the repository root:

```text
4 passed in 0.10s
python -m py_compile: passed silently
```