### PR TITLE
Phase 8.9g: continue diagnostics after unsupported Flux structures

### DIFF
--- a/Database/backend/phase89g_targeted_flux_diagnostics.py
+++ b/Database/backend/phase89g_targeted_flux_diagnostics.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Mapping
+
+from phase89g_targeted_flux_analysis import (
+    FluxAnalysisPlanError,
+    _db_file_path,
+    _normalise_code,
+    _open_read_only,
+    _planned_insert_ids,
+    _safe_source_path,
+    _sha256_file,
+    default_layout_resolver,
+    load_plan,
+    plan_sha256,
+)
+
+TensorInspector = Callable[[Path], Mapping[str, Any]]
+Analyzer = Callable[[Path, str], Mapping[str, Any]]
+
+
+def _key_prefix(key: str) -> str:
+    text = str(key or "")
+    if "." in text:
+        return ".".join(text.split(".")[:3])
+    parts = text.split("_")
+    return "_".join(parts[:4]) if len(parts) > 1 else text
+
+
+def default_tensor_inspector(path: Path) -> Mapping[str, Any]:
+    from clip_contribution import is_clip_contributor
+    from safetensors import safe_open
+
+    with safe_open(str(path), framework="pt") as safetensors_file:
+        keys = sorted(str(key) for key in safetensors_file.keys())
+
+    clip_contributor, clip_tensor_count = is_clip_contributor(keys)
+    prefixes = Counter(_key_prefix(key) for key in keys)
+    return {
+        "tensor_key_count": len(keys),
+        "tensor_key_sample": keys[:25],
+        "tensor_key_prefix_counts": [
+            {"prefix": prefix, "count": count}
+            for prefix, count in prefixes.most_common(20)
+        ],
+        "clip_contributor": bool(clip_contributor),
+        "clip_tensor_count": int(clip_tensor_count),
+    }
+
+
+def default_analyzer(path: Path, base_model_code: str) -> Mapping[str, Any]:
+    from delta_inspector_engine import inspect_lora
+
+    return inspect_lora(str(path), base_model_code=base_model_code)
+
+
+def build_flux_diagnostics(
+    plan: Mapping[str, Any],
+    *,
+    library_root: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    db_path_root: str = "/loras",
+    expected_count: int = 3,
+    tensor_inspector: TensorInspector | None = None,
+    analyzer: Analyzer | None = None,
+) -> dict[str, Any]:
+    if plan.get("audit_mode") != "read-only":
+        raise FluxAnalysisPlanError(
+            "Phase 8.9g diagnostics accept only a Phase 8.9d read-only plan"
+        )
+
+    safety = plan.get("safety") or {}
+    if safety.get("writes_database") is not False:
+        raise FluxAnalysisPlanError(
+            "Plan safety flags do not describe a read-only planner run"
+        )
+
+    blockers = {
+        "unresolved_relocations": plan.get("unresolved_relocations") or [],
+        "stable_id_groups_exhausted": plan.get("stable_id_groups_exhausted") or [],
+        "existing_stable_id_issues": plan.get("existing_stable_id_issues") or [],
+    }
+    active_blockers = [name for name, values in blockers.items() if values]
+    if active_blockers:
+        raise FluxAnalysisPlanError(
+            "Plan has unresolved blockers: " + ", ".join(sorted(active_blockers))
+        )
+
+    candidates = [
+        dict(raw)
+        for raw in plan.get("new_metadata_insert_candidates", [])
+        if isinstance(raw, Mapping)
+        and _normalise_code(raw.get("base_model_code")) == "FLX"
+    ]
+    if len(candidates) != int(expected_count):
+        raise FluxAnalysisPlanError(
+            f"Expected exactly {expected_count} FLX candidates, found {len(candidates)}"
+        )
+
+    ids = _planned_insert_ids(plan)
+    root = Path(library_root).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise FluxAnalysisPlanError(f"Library root is not a directory: {root}")
+
+    tensor_inspector_fn = tensor_inspector or default_tensor_inspector
+    analyzer_fn = analyzer or default_analyzer
+
+    conn = _open_read_only(db_path)
+    try:
+        integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
+        if integrity.casefold() != "ok":
+            raise FluxAnalysisPlanError(
+                f"Database integrity check failed: {integrity}"
+            )
+
+        targets: list[dict[str, Any]] = []
+        for candidate in sorted(
+            candidates,
+            key=lambda item: str(item.get("relative_path") or "").casefold(),
+        ):
+            if str(candidate.get("source_type") or "") != "new_metadata_insert":
+                raise FluxAnalysisPlanError(
+                    "FLX candidate is not marked as new_metadata_insert"
+                )
+
+            relative = PurePosixPath(
+                str(candidate.get("relative_path") or "")
+            ).as_posix()
+            if not relative or relative == ".":
+                raise FluxAnalysisPlanError(
+                    "FLX candidate is missing relative_path"
+                )
+
+            category_code = _normalise_code(candidate.get("category_code"))
+            if not category_code:
+                raise FluxAnalysisPlanError(
+                    f"FLX candidate has no category code: {relative}"
+                )
+
+            stable_id = ids.get(relative.casefold())
+            if not stable_id:
+                raise FluxAnalysisPlanError(
+                    f"No planned stable ID for FLX candidate: {relative}"
+                )
+            expected_prefix = f"FLX-{category_code}-"
+            if not stable_id.startswith(expected_prefix):
+                raise FluxAnalysisPlanError(
+                    f"Planned stable ID {stable_id} does not match "
+                    f"{expected_prefix} for {relative}"
+                )
+
+            source = _safe_source_path(root, relative)
+            db_file_path = _db_file_path(db_path_root, relative)
+
+            if conn.execute(
+                "SELECT 1 FROM lora WHERE file_path = ?", (db_file_path,)
+            ).fetchone() is not None:
+                raise FluxAnalysisPlanError(
+                    f"Target file_path already exists in DB: {db_file_path}"
+                )
+            if conn.execute(
+                "SELECT 1 FROM lora WHERE stable_id = ?", (stable_id,)
+            ).fetchone() is not None:
+                raise FluxAnalysisPlanError(
+                    f"Planned stable ID already exists in DB: {stable_id}"
+                )
+
+            tensor_info: dict[str, Any] = {}
+            tensor_error: dict[str, str] | None = None
+            try:
+                tensor_info = dict(tensor_inspector_fn(source))
+            except Exception as exc:
+                tensor_error = {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+
+            analysis: dict[str, Any] = {}
+            analysis_error: dict[str, str] | None = None
+            if tensor_error is None:
+                try:
+                    analysis = dict(analyzer_fn(source, "FLX"))
+                except Exception as exc:
+                    analysis_error = {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+
+            block_weights = [
+                float(value) for value in (analysis.get("block_weights") or [])
+            ]
+            raw_strengths = [
+                float(value)
+                for value in (analysis.get("raw_block_strengths") or [])
+            ]
+            block_layout = (
+                default_layout_resolver(
+                    analysis.get("lora_type"), len(block_weights)
+                )
+                if analysis_error is None and tensor_error is None
+                else None
+            )
+
+            warnings: list[str] = []
+            if tensor_error is not None:
+                warnings.append(
+                    "Tensor-key inspection failed; candidate is blocked"
+                )
+            if analysis_error is not None:
+                warnings.append(
+                    "Flux/UNet analysis did not recognise this tensor structure"
+                )
+            if block_weights and block_layout is None:
+                warnings.append(
+                    f"No supported block layout for {len(block_weights)} analysed blocks"
+                )
+            if raw_strengths and len(raw_strengths) != len(block_weights):
+                warnings.append(
+                    "raw_block_strengths count does not match block_weights count"
+                )
+
+            ready = not warnings
+            targets.append(
+                {
+                    "relative_path": relative,
+                    "db_file_path": db_file_path,
+                    "filename": candidate.get("filename") or source.name,
+                    "planned_stable_id": stable_id,
+                    "base_model_name": candidate.get("base_model_name"),
+                    "base_model_code": "FLX",
+                    "category_name": candidate.get("category_name"),
+                    "category_code": category_code,
+                    "source_size_bytes": source.stat().st_size,
+                    "source_mtime": source.stat().st_mtime,
+                    "source_sha256": _sha256_file(source),
+                    **tensor_info,
+                    "tensor_inspection_error": tensor_error,
+                    "analysis_error": analysis_error,
+                    "model_family": analysis.get("model_family"),
+                    "lora_type": analysis.get("lora_type"),
+                    "rank": analysis.get("rank"),
+                    "has_block_weights": bool(block_weights),
+                    "block_count": len(block_weights),
+                    "raw_strength_count": len(raw_strengths),
+                    "block_layout": block_layout,
+                    "block_weight_min": min(block_weights) if block_weights else None,
+                    "block_weight_max": max(block_weights) if block_weights else None,
+                    "block_weight_mean": (
+                        sum(block_weights) / len(block_weights)
+                        if block_weights
+                        else None
+                    ),
+                    "warnings": warnings,
+                    "ready_for_controlled_apply": ready,
+                }
+            )
+
+        ready_count = sum(
+            1 for target in targets if target["ready_for_controlled_apply"]
+        )
+        return {
+            "phase": "8.9g-diagnostics",
+            "mode": "read-only resilient targeted FLX diagnostics",
+            "plan_sha256": plan_sha256(plan),
+            "summary": {
+                "flux_candidates": len(targets),
+                "ready_for_controlled_apply": ready_count,
+                "blocked_candidates": len(targets) - ready_count,
+                "tensor_inspection_errors": sum(
+                    1 for target in targets
+                    if target.get("tensor_inspection_error") is not None
+                ),
+                "analysis_errors": sum(
+                    1 for target in targets
+                    if target.get("analysis_error") is not None
+                ),
+                "total_analysed_block_rows": sum(
+                    int(target["block_count"]) for target in targets
+                ),
+            },
+            "targets": targets,
+            "safety": {
+                "database_open_mode": (
+                    "SQLite URI mode=ro plus PRAGMA query_only=ON"
+                ),
+                "writes_database": False,
+                "runs_full_indexer": False,
+                "discovers_library_files": False,
+                "opens_only_plan_listed_safetensors": True,
+                "assigns_stable_ids": False,
+                "deletes_rows": False,
+                "continues_after_per_file_analysis_error": True,
+            },
+        }
+    finally:
+        conn.close()
+
+
+def print_diagnostics(result: Mapping[str, Any]) -> None:
+    summary = result["summary"]
+    print("=== Phase 8.9g targeted FLX diagnostics ===")
+    print(f"Mode                       : {result['mode']}")
+    print(f"Plan SHA-256               : {result['plan_sha256']}")
+    print(f"FLX candidates             : {summary['flux_candidates']}")
+    print(
+        "Ready for controlled apply : "
+        f"{summary['ready_for_controlled_apply']}"
+    )
+    print(f"Blocked candidates         : {summary['blocked_candidates']}")
+    print(f"Tensor inspection errors   : {summary['tensor_inspection_errors']}")
+    print(f"Analysis errors            : {summary['analysis_errors']}")
+    print()
+    for target in result["targets"]:
+        print(target["relative_path"])
+        print(f"  stable_id       : {target['planned_stable_id']}")
+        print(f"  sha256          : {target['source_sha256']}")
+        print(f"  tensor keys     : {target.get('tensor_key_count')}")
+        print(
+            "  analysis        : "
+            f"family={target.get('model_family')!r}, "
+            f"type={target.get('lora_type')!r}, "
+            f"rank={target.get('rank')!r}"
+        )
+        print(
+            "  blocks          : "
+            f"{target['block_count']} ({target.get('block_layout')})"
+        )
+        print(f"  analysis error  : {target.get('analysis_error')}")
+        print(f"  ready           : {target['ready_for_controlled_apply']}")
+        for warning in target["warnings"]:
+            print(f"  warning         : {warning}")
+        print()
+    print("No database changes were made.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run resilient read-only diagnostics for the three Phase 8.9g FLX targets"
+        )
+    )
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--db-path-root", default="/loras")
+    parser.add_argument("--expected-count", type=int, default=3)
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    result = build_flux_diagnostics(
+        load_plan(args.plan),
+        library_root=args.root,
+        db_path=args.db,
+        db_path_root=args.db_path_root,
+        expected_count=args.expected_count,
+    )
+    print_diagnostics(result)
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        print(f"JSON diagnostics written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/tests/test_phase89g_targeted_flux_diagnostics.py
+++ b/Database/backend/tests/test_phase89g_targeted_flux_diagnostics.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from phase89g_targeted_flux_analysis import FluxAnalysisPlanError  # noqa: E402
+from phase89g_targeted_flux_diagnostics import build_flux_diagnostics  # noqa: E402
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _create_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            stable_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _plan(count: int = 3) -> dict:
+    candidates = []
+    planned = []
+    for index in range(1, count + 1):
+        relative = f"FLUX/03 - Utils/target-{index}.safetensors"
+        candidates.append(
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": relative,
+                "filename": f"target-{index}.safetensors",
+                "base_model_name": "Flux",
+                "base_model_code": "FLX",
+                "category_name": "Utils",
+                "category_code": "UTL",
+            }
+        )
+        planned.append(
+            {
+                "source_type": "new_metadata_insert",
+                "relative_path": relative,
+                "planned_stable_id": f"FLX-UTL-{index:03d}",
+            }
+        )
+    return {
+        "audit_mode": "read-only",
+        "safety": {"writes_database": False},
+        "unresolved_relocations": [],
+        "stable_id_groups_exhausted": [],
+        "existing_stable_id_issues": [],
+        "new_metadata_insert_candidates": candidates,
+        "planned_stable_ids": planned,
+    }
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "loras"
+    db = tmp_path / "lora_master.db"
+    for index in range(1, 4):
+        path = root / "FLUX" / "03 - Utils" / f"target-{index}.safetensors"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"target-{index}".encode("utf-8"))
+    _create_db(db)
+    return root, db
+
+
+def _tensor_inspector(path: Path) -> dict:
+    return {
+        "tensor_key_count": 4,
+        "tensor_key_sample": [f"sample.{path.stem}.key"],
+        "tensor_key_prefix_counts": [{"prefix": "sample", "count": 4}],
+        "clip_contributor": False,
+        "clip_tensor_count": 0,
+    }
+
+
+def test_analysis_error_is_captured_and_other_targets_continue(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+
+    def analyzer(path: Path, base_model_code: str) -> dict:
+        assert base_model_code == "FLX"
+        if path.name == "target-2.safetensors":
+            raise ValueError("No recognised Flux-style structures found")
+        return {
+            "model_family": "flux",
+            "lora_type": "unknown-no-blocks",
+            "rank": None,
+            "block_weights": [],
+            "raw_block_strengths": [],
+        }
+
+    before = _sha256(db)
+    result = build_flux_diagnostics(
+        _plan(),
+        library_root=root,
+        db_path=db,
+        tensor_inspector=_tensor_inspector,
+        analyzer=analyzer,
+    )
+    after = _sha256(db)
+
+    assert before == after
+    assert result["summary"] == {
+        "flux_candidates": 3,
+        "ready_for_controlled_apply": 2,
+        "blocked_candidates": 1,
+        "tensor_inspection_errors": 0,
+        "analysis_errors": 1,
+        "total_analysed_block_rows": 0,
+    }
+    assert len(result["targets"]) == 3
+
+    by_name = {target["filename"]: target for target in result["targets"]}
+    failed = by_name["target-2.safetensors"]
+    assert failed["ready_for_controlled_apply"] is False
+    assert failed["analysis_error"]["type"] == "ValueError"
+    assert "No recognised" in failed["analysis_error"]["message"]
+    assert failed["tensor_key_sample"] == ["sample.target-2.key"]
+
+    assert by_name["target-1.safetensors"]["ready_for_controlled_apply"] is True
+    assert by_name["target-3.safetensors"]["ready_for_controlled_apply"] is True
+
+
+def test_tensor_error_is_captured_without_calling_analyzer(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+    analyzer_calls: list[str] = []
+
+    def tensor_inspector(path: Path) -> dict:
+        if path.name == "target-1.safetensors":
+            raise RuntimeError("broken safetensors header")
+        return _tensor_inspector(path)
+
+    def analyzer(path: Path, base_model_code: str) -> dict:
+        analyzer_calls.append(path.name)
+        return {
+            "model_family": "flux",
+            "lora_type": "unknown-no-blocks",
+            "rank": None,
+            "block_weights": [],
+            "raw_block_strengths": [],
+        }
+
+    result = build_flux_diagnostics(
+        _plan(),
+        library_root=root,
+        db_path=db,
+        tensor_inspector=tensor_inspector,
+        analyzer=analyzer,
+    )
+
+    assert result["summary"]["tensor_inspection_errors"] == 1
+    assert result["summary"]["blocked_candidates"] == 1
+    assert "target-1.safetensors" not in analyzer_calls
+    assert set(analyzer_calls) == {
+        "target-2.safetensors",
+        "target-3.safetensors",
+    }
+
+
+def test_candidate_count_guard_remains_strict(tmp_path: Path) -> None:
+    root, db = _fixture(tmp_path)
+
+    with pytest.raises(FluxAnalysisPlanError, match="Expected exactly 3"):
+        build_flux_diagnostics(
+            _plan(count=2),
+            library_root=root,
+            db_path=db,
+            tensor_inspector=_tensor_inspector,
+            analyzer=lambda path, code: {},
+        )

--- a/docs/phase89g-targeted-flux-diagnostics.md
+++ b/docs/phase89g-targeted-flux-diagnostics.md
@@ -1,0 +1,61 @@
+# Phase 8.9g targeted Flux diagnostics
+
+This companion diagnostic runner addresses one operational limitation found during the live Phase 8.9g analysis: an unsupported tensor structure previously stopped the whole three-file process.
+
+The diagnostic runner keeps the same read-only scope and path/ID guards, but captures per-file tensor or analysis errors and continues to the remaining plan-listed candidates.
+
+## Live issue observed
+
+The first production run reached the Flux analysis engine and reported that one target contained none of the currently recognised structures:
+
+- `transformer.single_transformer_blocks.<idx>.*`
+- `lora_unet_double_blocks_<idx>_*`
+- Flux text-encoder-only keys
+- UNet-57 keys
+
+The SQLite SHA-256 remained unchanged.
+
+## Diagnostic output
+
+For every one of the three targets, the report records:
+
+- source filename, size, mtime and SHA-256
+- planned stable ID and database path
+- tensor-key count
+- the first 25 sorted tensor keys
+- the 20 most common key prefixes
+- CLIP contribution metadata
+- Flux analysis result, when recognised
+- exception type and message, when not recognised
+- warnings and controlled-apply readiness
+
+An unsupported structure is reported as a blocked candidate rather than terminating the report.
+
+## Safety boundary
+
+The runner:
+
+- opens SQLite with URI `mode=ro`
+- enables `PRAGMA query_only = ON`
+- opens only the three paths selected from the reviewed Phase 8.9d plan
+- does not enumerate the LoRA library
+- does not call `lora_indexer.main()`
+- does not assign IDs
+- does not insert or update rows
+- does not alter block weights
+- has no apply mode
+
+## Validation
+
+From Bender:
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89g_targeted_flux_diagnostics.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89g_targeted_flux_diagnostics.py
+```
+
+The tests verify that analysis and tensor-inspection failures are isolated per file, all three targets remain represented, and the database bytes remain unchanged.


### PR DESCRIPTION
## What changed

- Added a read-only companion diagnostic runner for the three Phase 8.9g FLX targets.
- Preserves the reviewed plan, path, stable-ID and SQLite read-only guards.
- Captures tensor-inspection and Flux-analysis exceptions per file instead of aborting the whole report.
- Continues through all three candidates and records tensor-key samples and key-prefix counts for architecture diagnosis.
- Marks unsupported candidates blocked from any later apply.
- Added focused tests and a runbook.

## Live failure addressed

The first container run reached the Flux analyser but one target had no recognised Flux transformer, Flux UNet, Flux TE-only or UNet-57 key structure. The process exited before reporting the remaining candidates.

The companion runner treats that as a per-file blocked result, while retaining all three candidates in the JSON report.

## Safety

- SQLite URI `mode=ro` and `PRAGMA query_only = ON`.
- Opens only the three plan-listed safetensors paths.
- No full-library discovery.
- No indexer invocation.
- No inserts, updates, stable-ID assignments, block-weight writes, relocations or deletions.
- No apply mode.

## Validation

Verified on Bender from the repository root:

```text
3 passed in 0.09s
python -m py_compile: passed silently
```