### PR TITLE
Phase 8.9h: seal the single ready Flux candidate

### DIFF
--- a/Database/backend/phase89h_sealed_flux_artifact.py
+++ b/Database/backend/phase89h_sealed_flux_artifact.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from phase89g_targeted_flux_analysis import (
+    FluxAnalysisPlanError,
+    _open_read_only,
+    _safe_source_path,
+    _sha256_file,
+    default_layout_resolver,
+    load_plan,
+    plan_sha256,
+)
+from phase89g_targeted_flux_diagnostics import default_tensor_inspector
+
+
+class SealedArtifactError(RuntimeError):
+    pass
+
+
+Analyzer = Callable[[Path, str], Mapping[str, Any]]
+TensorInspector = Callable[[Path], Mapping[str, Any]]
+
+
+def load_json_object(path: str | os.PathLike[str], label: str) -> dict[str, Any]:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    with resolved.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise SealedArtifactError(f"{label} JSON must contain an object")
+    return value
+
+
+def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def default_analyzer(path: Path, base_model_code: str) -> Mapping[str, Any]:
+    from delta_inspector_engine import inspect_lora
+
+    return inspect_lora(str(path), base_model_code=base_model_code)
+
+
+def _require_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise SealedArtifactError(
+            f"{label} mismatch: expected {expected!r}, found {actual!r}"
+        )
+
+
+def _ready_targets(diagnostics: Mapping[str, Any]) -> list[dict[str, Any]]:
+    targets = diagnostics.get("targets") or []
+    return [
+        dict(target)
+        for target in targets
+        if isinstance(target, Mapping)
+        and target.get("ready_for_controlled_apply") is True
+    ]
+
+
+def build_sealed_flux_artifact(
+    plan: Mapping[str, Any],
+    diagnostics: Mapping[str, Any],
+    *,
+    library_root: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    expected_stable_id: str = "FLX-PPL-207",
+    expected_block_count: int = 57,
+    expected_layout: str = "flux_unet_57",
+    analyzer: Analyzer | None = None,
+    tensor_inspector: TensorInspector | None = None,
+) -> dict[str, Any]:
+    if plan.get("audit_mode") != "read-only":
+        raise SealedArtifactError("Phase 8.9h requires the Phase 8.9d read-only plan")
+
+    expected_plan_sha = plan_sha256(plan)
+    _require_equal(
+        diagnostics.get("plan_sha256"),
+        expected_plan_sha,
+        "diagnostics plan_sha256",
+    )
+    _require_equal(diagnostics.get("phase"), "8.9g-diagnostics", "diagnostics phase")
+
+    ready = _ready_targets(diagnostics)
+    if len(ready) != 1:
+        raise SealedArtifactError(
+            f"Expected exactly one ready diagnostic target, found {len(ready)}"
+        )
+
+    target = ready[0]
+    stable_id = str(target.get("planned_stable_id") or "").strip().upper()
+    _require_equal(stable_id, expected_stable_id.upper(), "ready stable_id")
+    _require_equal(target.get("base_model_code"), "FLX", "base_model_code")
+    _require_equal(target.get("block_count"), int(expected_block_count), "diagnostic block_count")
+    _require_equal(target.get("raw_strength_count"), int(expected_block_count), "diagnostic raw_strength_count")
+    _require_equal(target.get("block_layout"), expected_layout, "diagnostic block_layout")
+    _require_equal(target.get("warnings"), [], "diagnostic warnings")
+    _require_equal(target.get("analysis_error"), None, "diagnostic analysis_error")
+    _require_equal(
+        target.get("tensor_inspection_error"),
+        None,
+        "diagnostic tensor_inspection_error",
+    )
+
+    relative_path = str(target.get("relative_path") or "").strip()
+    if not relative_path:
+        raise SealedArtifactError("Ready diagnostic target has no relative_path")
+
+    root = Path(library_root).expanduser().resolve(strict=True)
+    source = _safe_source_path(root, relative_path)
+    source_sha = _sha256_file(source)
+    _require_equal(source_sha, target.get("source_sha256"), "source SHA-256")
+
+    db_file_path = str(target.get("db_file_path") or "").strip()
+    if not db_file_path:
+        raise SealedArtifactError("Ready diagnostic target has no db_file_path")
+
+    conn = _open_read_only(db_path)
+    try:
+        integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
+        if integrity.casefold() != "ok":
+            raise SealedArtifactError(
+                f"Database integrity check failed: {integrity}"
+            )
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE file_path = ?", (db_file_path,)
+        ).fetchone() is not None:
+            raise SealedArtifactError(
+                f"Target file_path already exists in DB: {db_file_path}"
+            )
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE stable_id = ?", (stable_id,)
+        ).fetchone() is not None:
+            raise SealedArtifactError(
+                f"Planned stable ID already exists in DB: {stable_id}"
+            )
+    finally:
+        conn.close()
+
+    tensor_inspector_fn = tensor_inspector or default_tensor_inspector
+    tensor_info = dict(tensor_inspector_fn(source))
+    for field in (
+        "tensor_key_count",
+        "clip_contributor",
+        "clip_tensor_count",
+    ):
+        _require_equal(tensor_info.get(field), target.get(field), f"tensor {field}")
+
+    analyzer_fn = analyzer or default_analyzer
+    analysis = dict(analyzer_fn(source, "FLX"))
+    block_weights = [
+        float(value) for value in (analysis.get("block_weights") or [])
+    ]
+    raw_strengths = [
+        float(value) for value in (analysis.get("raw_block_strengths") or [])
+    ]
+    if len(block_weights) != int(expected_block_count):
+        raise SealedArtifactError(
+            f"Expected {expected_block_count} block weights, found {len(block_weights)}"
+        )
+    if len(raw_strengths) != len(block_weights):
+        raise SealedArtifactError(
+            "raw_block_strengths count does not match block_weights count"
+        )
+
+    layout = default_layout_resolver(analysis.get("lora_type"), len(block_weights))
+    _require_equal(layout, expected_layout, "re-analysed block_layout")
+    for field in ("model_family", "lora_type", "rank"):
+        _require_equal(analysis.get(field), target.get(field), f"analysis {field}")
+
+    payload: dict[str, Any] = {
+        "phase": "8.9h",
+        "mode": "read-only sealed single-target Flux artifact",
+        "plan_sha256": expected_plan_sha,
+        "diagnostics_sha256": canonical_sha256(diagnostics),
+        "target": {
+            "relative_path": relative_path,
+            "db_file_path": db_file_path,
+            "filename": target.get("filename") or source.name,
+            "planned_stable_id": stable_id,
+            "base_model_name": target.get("base_model_name"),
+            "base_model_code": "FLX",
+            "category_name": target.get("category_name"),
+            "category_code": target.get("category_code"),
+            "source_size_bytes": source.stat().st_size,
+            "source_mtime": source.stat().st_mtime,
+            "source_sha256": source_sha,
+            "tensor_key_count": tensor_info.get("tensor_key_count"),
+            "clip_contributor": bool(tensor_info.get("clip_contributor")),
+            "clip_tensor_count": int(tensor_info.get("clip_tensor_count") or 0),
+            "model_family": analysis.get("model_family"),
+            "lora_type": analysis.get("lora_type"),
+            "rank": analysis.get("rank"),
+            "has_block_weights": True,
+            "block_layout": layout,
+            "block_count": len(block_weights),
+            "block_weights": block_weights,
+            "raw_block_strengths": raw_strengths,
+        },
+        "safety": {
+            "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+            "writes_database": False,
+            "runs_full_indexer": False,
+            "discovers_library_files": False,
+            "opens_only_diagnostic_target": True,
+            "assigns_stable_ids": False,
+            "deletes_rows": False,
+            "contains_apply_mode": False,
+        },
+    }
+    payload["artifact_sha256"] = canonical_sha256(payload)
+    return payload
+
+
+def verify_artifact_digest(artifact: Mapping[str, Any]) -> str:
+    stored = str(artifact.get("artifact_sha256") or "")
+    unsigned = dict(artifact)
+    unsigned.pop("artifact_sha256", None)
+    calculated = canonical_sha256(unsigned)
+    if stored != calculated:
+        raise SealedArtifactError(
+            f"Artifact digest mismatch: stored {stored}, calculated {calculated}"
+        )
+    return calculated
+
+
+def print_artifact(artifact: Mapping[str, Any]) -> None:
+    target = artifact["target"]
+    print("=== Phase 8.9h sealed Flux artifact ===")
+    print(f"Mode             : {artifact['mode']}")
+    print(f"Plan SHA-256     : {artifact['plan_sha256']}")
+    print(f"Diagnostics SHA  : {artifact['diagnostics_sha256']}")
+    print(f"Artifact SHA-256 : {artifact['artifact_sha256']}")
+    print(f"Stable ID        : {target['planned_stable_id']}")
+    print(f"Source SHA-256   : {target['source_sha256']}")
+    print(f"Block layout     : {target['block_layout']}")
+    print(f"Block rows       : {target['block_count']}")
+    print("No database changes were made.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a sealed read-only artifact for the single ready Phase 8.9g FLX target"
+    )
+    parser.add_argument("--plan", required=True)
+    parser.add_argument("--diagnostics", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--expected-stable-id", default="FLX-PPL-207")
+    parser.add_argument("--expected-block-count", type=int, default=57)
+    parser.add_argument("--expected-layout", default="flux_unet_57")
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    artifact = build_sealed_flux_artifact(
+        load_plan(args.plan),
+        load_json_object(args.diagnostics, "Diagnostics"),
+        library_root=args.root,
+        db_path=args.db,
+        expected_stable_id=args.expected_stable_id,
+        expected_block_count=args.expected_block_count,
+        expected_layout=args.expected_layout,
+    )
+    verify_artifact_digest(artifact)
+    print_artifact(artifact)
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        print(f"JSON artifact written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/tests/test_phase89h_sealed_flux_artifact.py
+++ b/Database/backend/tests/test_phase89h_sealed_flux_artifact.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from phase89g_targeted_flux_analysis import plan_sha256
+from phase89h_sealed_flux_artifact import (
+    SealedArtifactError,
+    build_sealed_flux_artifact,
+    verify_artifact_digest,
+)
+
+
+STABLE_ID = "FLX-PPL-207"
+RELATIVE_PATH = "FLUX/01 - People/ang3l4wh1t3-f1.safetensors"
+DB_FILE_PATH = f"/loras/{RELATIVE_PATH}"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _db(path: Path) -> Path:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            stable_id TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _plan() -> dict[str, object]:
+    return {
+        "audit_mode": "read-only",
+        "safety": {"writes_database": False},
+        "new_metadata_insert_candidates": [],
+    }
+
+
+def _diagnostics(plan: dict[str, object], source_sha: str) -> dict[str, object]:
+    return {
+        "phase": "8.9g-diagnostics",
+        "plan_sha256": plan_sha256(plan),
+        "summary": {
+            "flux_candidates": 3,
+            "ready_for_controlled_apply": 1,
+            "blocked_candidates": 2,
+        },
+        "targets": [
+            {
+                "relative_path": RELATIVE_PATH,
+                "db_file_path": DB_FILE_PATH,
+                "filename": "ang3l4wh1t3-f1.safetensors",
+                "planned_stable_id": STABLE_ID,
+                "base_model_name": "Flux",
+                "base_model_code": "FLX",
+                "category_name": "People",
+                "category_code": "PPL",
+                "source_sha256": source_sha,
+                "tensor_key_count": 912,
+                "clip_contributor": False,
+                "clip_tensor_count": 0,
+                "tensor_inspection_error": None,
+                "analysis_error": None,
+                "model_family": "Flux",
+                "lora_type": "Flux (UNet double+single blocks)",
+                "rank": None,
+                "block_count": 57,
+                "raw_strength_count": 57,
+                "block_layout": "flux_unet_57",
+                "warnings": [],
+                "ready_for_controlled_apply": True,
+            },
+            {
+                "relative_path": "FLUX/02 - Styles/blocked.safetensors",
+                "planned_stable_id": "FLX-STL-263",
+                "ready_for_controlled_apply": False,
+            },
+            {
+                "relative_path": "FLUX/05 - Body/broken.safetensors",
+                "planned_stable_id": "FLX-BDY-071",
+                "ready_for_controlled_apply": False,
+            },
+        ],
+        "safety": {"writes_database": False},
+    }
+
+
+def _source(root: Path) -> Path:
+    source = root / Path(*RELATIVE_PATH.split("/"))
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"sealed-fixture")
+    return source
+
+
+def _tensor_inspector(_: Path) -> dict[str, object]:
+    return {
+        "tensor_key_count": 912,
+        "clip_contributor": False,
+        "clip_tensor_count": 0,
+        "tensor_key_sample": [],
+        "tensor_key_prefix_counts": [],
+    }
+
+
+def _analyzer(_: Path, base_model_code: str) -> dict[str, object]:
+    assert base_model_code == "FLX"
+    return {
+        "model_family": "Flux",
+        "lora_type": "Flux (UNet double+single blocks)",
+        "rank": None,
+        "block_weights": [index / 56 for index in range(57)],
+        "raw_block_strengths": [float(index + 1) for index in range(57)],
+    }
+
+
+def test_builds_sealed_artifact_without_changing_db(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    plan = _plan()
+    diagnostics = _diagnostics(plan, _sha256(source))
+    db_before = db.read_bytes()
+
+    artifact = build_sealed_flux_artifact(
+        plan,
+        diagnostics,
+        library_root=root,
+        db_path=db,
+        analyzer=_analyzer,
+        tensor_inspector=_tensor_inspector,
+    )
+
+    assert artifact["phase"] == "8.9h"
+    assert artifact["target"]["planned_stable_id"] == STABLE_ID
+    assert artifact["target"]["block_count"] == 57
+    assert len(artifact["target"]["block_weights"]) == 57
+    assert len(artifact["target"]["raw_block_strengths"]) == 57
+    assert verify_artifact_digest(artifact) == artifact["artifact_sha256"]
+    assert db.read_bytes() == db_before
+
+
+def test_rejects_source_hash_change(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    plan = _plan()
+    diagnostics = _diagnostics(plan, _sha256(source))
+    source.write_bytes(b"changed-after-diagnostics")
+
+    with pytest.raises(SealedArtifactError, match="source SHA-256 mismatch"):
+        build_sealed_flux_artifact(
+            plan,
+            diagnostics,
+            library_root=root,
+            db_path=db,
+            analyzer=_analyzer,
+            tensor_inspector=_tensor_inspector,
+        )
+
+
+def test_rejects_existing_stable_id(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO lora (file_path, stable_id) VALUES (?, ?)",
+        ("/loras/existing.safetensors", STABLE_ID),
+    )
+    conn.commit()
+    conn.close()
+    plan = _plan()
+    diagnostics = _diagnostics(plan, _sha256(source))
+
+    with pytest.raises(SealedArtifactError, match="Planned stable ID already exists"):
+        build_sealed_flux_artifact(
+            plan,
+            diagnostics,
+            library_root=root,
+            db_path=db,
+            analyzer=_analyzer,
+            tensor_inspector=_tensor_inspector,
+        )
+
+
+def test_requires_exactly_one_ready_target(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    plan = _plan()
+    diagnostics = _diagnostics(plan, _sha256(source))
+    second = dict(diagnostics["targets"][1])
+    second["ready_for_controlled_apply"] = True
+    diagnostics["targets"][1] = second
+
+    with pytest.raises(SealedArtifactError, match="exactly one ready"):
+        build_sealed_flux_artifact(
+            plan,
+            diagnostics,
+            library_root=root,
+            db_path=db,
+            analyzer=_analyzer,
+            tensor_inspector=_tensor_inspector,
+        )

--- a/Database/backend/tests/test_phase89h_sealed_flux_artifact.py
+++ b/Database/backend/tests/test_phase89h_sealed_flux_artifact.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
 
 from phase89g_targeted_flux_analysis import plan_sha256
 from phase89h_sealed_flux_artifact import (

--- a/docs/phase89h-sealed-flux-artifact.md
+++ b/docs/phase89h-sealed-flux-artifact.md
@@ -1,0 +1,82 @@
+# Phase 8.9h sealed Flux artifact
+
+Phase 8.9h creates a read-only, canonical JSON artifact for the single Phase 8.9g candidate that passed live diagnostics: `FLX-PPL-207`.
+
+It does not write to SQLite and has no apply mode.
+
+## Purpose
+
+The live diagnostics established that one of the three excluded FLX candidates is fully analysable:
+
+- path: `FLUX/01 - People/ang3l4wh1t3-f1.safetensors`
+- planned stable ID: `FLX-PPL-207`
+- source SHA-256: `9f06e750055f524998cca621e25fca3672a0e6dbf836b8d63c6146348c04cf9d`
+- layout: `flux_unet_57`
+- block weights: 57
+- raw strengths: 57
+
+The other two candidates remain blocked and are not included in this artifact.
+
+## Guard conditions
+
+The generator requires:
+
+- the Phase 8.9d plan digest to match the diagnostics report
+- diagnostics phase `8.9g-diagnostics`
+- exactly one target marked ready for controlled apply
+- stable ID exactly `FLX-PPL-207`
+- source SHA unchanged since diagnostics
+- current database integrity check `ok`
+- target file path still absent from SQLite
+- target stable ID still unused
+- tensor-key count and CLIP metadata unchanged
+- model family, LoRA type and rank unchanged
+- exactly 57 block weights and 57 raw strengths
+- layout exactly `flux_unet_57`
+
+SQLite is opened with URI `mode=ro` and `PRAGMA query_only = ON`.
+
+## Artifact contents
+
+The output JSON contains:
+
+- plan and diagnostics SHA-256 digests
+- source path, size, mtime and SHA-256
+- planned family/category metadata and stable ID
+- tensor and CLIP metadata
+- model family, LoRA type and rank
+- all 57 normalised block weights
+- all 57 raw strengths
+- a canonical artifact SHA-256
+
+A later write phase must require the exact artifact digest before it can insert anything.
+
+## Bender validation
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89h_sealed_flux_artifact.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89h_sealed_flux_artifact.py
+```
+
+## Planned Nibbler run
+
+The generator should run inside a temporary backend container so that `safetensors`, PyTorch and the existing analysis engine are available without modifying Nibbler's host Python environment.
+
+```bash
+sudo docker compose --env-file .env run --rm --no-deps -T backend \
+  python phase89h_sealed_flux_artifact.py \
+  --plan /data/phase89d_index_plan.json \
+  --diagnostics /data/phase89g_flux_diagnostics.json \
+  --root /loras \
+  --db /data/lora_master.db \
+  --expected-stable-id FLX-PPL-207 \
+  --expected-block-count 57 \
+  --expected-layout flux_unet_57 \
+  --json /data/phase89h_flx_ppl_207_artifact.json
+```
+
+The database SHA-256 must be identical before and after the run.


### PR DESCRIPTION
## What changed

- Added a read-only Phase 8.9h generator for the single FLX candidate that passed live diagnostics.
- Requires exactly one ready target and stable ID `FLX-PPL-207`.
- Revalidates the Phase 8.9d plan digest, Phase 8.9g diagnostics, source SHA-256, SQLite absence, tensor metadata, analysed model metadata, 57 block weights, 57 raw strengths and `flux_unet_57` layout.
- Emits all 57 normalised block weights and raw strengths into a canonical JSON artifact.
- Adds a canonical artifact SHA-256 that a later write phase must require exactly.
- Added focused tests and an operational runbook.

## Safety boundary

- SQLite opens with URI `mode=ro` and `PRAGMA query_only = ON`.
- No insert, update or delete statements.
- No full indexer invocation or library enumeration.
- Opens only the one diagnostics-approved source file.
- No stable-ID assignment.
- No apply mode exists.
- The two blocked FLX candidates are excluded.

## Validation

Verified on Bender from the repository root:

```text
4 passed in 0.09s
python -m py_compile: passed silently
```

The only follow-up commit corrected the test module import path; the sealed-artifact implementation was unchanged.