### PR TITLE
Phase 8.9j: add targeted PEFT Flux analysis

### DIFF
--- a/Database/backend/phase89j_targeted_peft_flux_analysis.py
+++ b/Database/backend/phase89j_targeted_peft_flux_analysis.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import torch
+
+from phase89g_targeted_flux_analysis import (
+    FluxAnalysisPlanError,
+    _open_read_only,
+    _safe_source_path,
+    _sha256_file,
+)
+
+
+class PeftFluxAnalysisError(RuntimeError):
+    pass
+
+
+EXPECTED_STABLE_ID = "FLX-STL-263"
+EXPECTED_SOURCE_SHA256 = (
+    "c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7"
+)
+EXPECTED_LAYOUT = "flux_unet_57"
+DOUBLE_BLOCK_COUNT = 19
+SINGLE_BLOCK_COUNT = 38
+TOTAL_BLOCK_COUNT = DOUBLE_BLOCK_COUNT + SINGLE_BLOCK_COUNT
+
+_BLOCK_KEY_RE = re.compile(
+    r"^base_model\.model\.(double_blocks|single_blocks)\.(\d+)\."
+    r"(.+)\.lora_([ab])\.weight$",
+    re.IGNORECASE,
+)
+_GLOBAL_KEY_RE = re.compile(
+    r"^base_model\.model\.(?!double_blocks\.|single_blocks\.)(.+)\."
+    r"lora_([ab])\.weight$",
+    re.IGNORECASE,
+)
+
+TensorAnalyser = Callable[[Path], Mapping[str, Any]]
+
+
+def load_json_object(path: str | os.PathLike[str], label: str) -> dict[str, Any]:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    with resolved.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise PeftFluxAnalysisError(f"{label} JSON must contain an object")
+    return value
+
+
+def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def verify_analysis_digest(result: Mapping[str, Any]) -> str:
+    stored = str(result.get("analysis_sha256") or "")
+    unsigned = dict(result)
+    unsigned.pop("analysis_sha256", None)
+    calculated = canonical_sha256(unsigned)
+    if stored != calculated:
+        raise PeftFluxAnalysisError(
+            f"Analysis digest mismatch: stored {stored}, calculated {calculated}"
+        )
+    return calculated
+
+
+def _tensor_norm(value: torch.Tensor) -> float:
+    norm = float(value.norm().item())
+    if not math.isfinite(norm):
+        raise PeftFluxAnalysisError("Encountered non-finite tensor norm")
+    return norm
+
+
+def _pair_rank(
+    module_name: str,
+    pair: Mapping[str, torch.Tensor],
+    blockers: list[str],
+) -> int | None:
+    a = pair.get("a")
+    b = pair.get("b")
+    if a is None or b is None:
+        missing = "A" if a is None else "B"
+        blockers.append(f"Incomplete LoRA pair for {module_name}: missing lora_{missing}")
+        return None
+    if a.ndim != 2 or b.ndim != 2:
+        blockers.append(
+            f"LoRA pair for {module_name} is not two-dimensional: "
+            f"A{tuple(a.shape)}, B{tuple(b.shape)}"
+        )
+        return None
+    rank_a = int(a.shape[0])
+    rank_b = int(b.shape[1])
+    if rank_a <= 0 or rank_b <= 0 or rank_a != rank_b:
+        blockers.append(
+            f"LoRA rank mismatch for {module_name}: A rank {rank_a}, B rank {rank_b}"
+        )
+        return None
+    return rank_a
+
+
+def _normalise_strengths(raw_strengths: list[float]) -> list[float]:
+    maximum = max(raw_strengths, default=0.0)
+    if maximum <= 0:
+        return [0.0 for _ in raw_strengths]
+    return [round(value / maximum, 6) for value in raw_strengths]
+
+
+def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, Any]:
+    block_modules: dict[tuple[str, int, str], dict[str, torch.Tensor]] = {}
+    global_modules: dict[str, dict[str, torch.Tensor]] = {}
+    unmatched_keys: list[str] = []
+
+    for raw_name, tensor in sorted(tensors.items(), key=lambda item: item[0].casefold()):
+        name = str(raw_name)
+        block_match = _BLOCK_KEY_RE.match(name)
+        if block_match:
+            stream = block_match.group(1).lower()
+            index = int(block_match.group(2))
+            module = block_match.group(3)
+            side = block_match.group(4).lower()
+            key = (stream, index, module)
+            pair = block_modules.setdefault(key, {})
+            if side in pair:
+                raise PeftFluxAnalysisError(
+                    f"Duplicate lora_{side.upper()} tensor for {stream}.{index}.{module}"
+                )
+            pair[side] = tensor
+            continue
+
+        global_match = _GLOBAL_KEY_RE.match(name)
+        if global_match:
+            module = global_match.group(1)
+            side = global_match.group(2).lower()
+            pair = global_modules.setdefault(module, {})
+            if side in pair:
+                raise PeftFluxAnalysisError(
+                    f"Duplicate lora_{side.upper()} tensor for global module {module}"
+                )
+            pair[side] = tensor
+            continue
+
+        unmatched_keys.append(name)
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    ranks: set[int] = set()
+    double_strengths: dict[int, float] = {}
+    single_strengths: dict[int, float] = {}
+
+    for (stream, index, module), pair in sorted(block_modules.items()):
+        max_index = DOUBLE_BLOCK_COUNT - 1 if stream == "double_blocks" else SINGLE_BLOCK_COUNT - 1
+        if index < 0 or index > max_index:
+            blockers.append(
+                f"Out-of-range {stream} index {index}; supported range is 0..{max_index}"
+            )
+
+        module_name = f"{stream}.{index}.{module}"
+        rank = _pair_rank(module_name, pair, blockers)
+        if rank is not None:
+            ranks.add(rank)
+
+        if "a" in pair and "b" in pair:
+            strength = _tensor_norm(pair["a"]) + _tensor_norm(pair["b"])
+            bucket = double_strengths if stream == "double_blocks" else single_strengths
+            bucket[index] = bucket.get(index, 0.0) + strength
+
+    global_module_names: list[str] = []
+    for module, pair in sorted(global_modules.items()):
+        global_module_names.append(module)
+        rank = _pair_rank(f"global.{module}", pair, blockers)
+        if rank is not None:
+            ranks.add(rank)
+        if "a" in pair:
+            _tensor_norm(pair["a"])
+        if "b" in pair:
+            _tensor_norm(pair["b"])
+
+    unmatched_lora_keys = [key for key in unmatched_keys if "lora_" in key.casefold()]
+    if unmatched_lora_keys:
+        blockers.append(
+            f"Found {len(unmatched_lora_keys)} unrecognised LoRA tensor key(s)"
+        )
+
+    observed_double = sorted(double_strengths)
+    observed_single = sorted(single_strengths)
+    if not observed_double:
+        blockers.append("No base_model.model.double_blocks LoRA pairs were found")
+    if not observed_single:
+        blockers.append("No base_model.model.single_blocks LoRA pairs were found")
+
+    missing_double = [index for index in range(DOUBLE_BLOCK_COUNT) if index not in double_strengths]
+    missing_single = [index for index in range(SINGLE_BLOCK_COUNT) if index not in single_strengths]
+    if missing_double or missing_single:
+        warnings.append(
+            "Unadapted Flux blocks are represented as zero strength in the 57-block layout"
+        )
+    if global_modules:
+        warnings.append(
+            "Global projection LoRA tensors are recorded separately and excluded from per-block strengths"
+        )
+    if len(ranks) > 1:
+        warnings.append("The file uses more than one LoRA rank across adapted modules")
+
+    raw_strengths = [double_strengths.get(index, 0.0) for index in range(DOUBLE_BLOCK_COUNT)]
+    raw_strengths.extend(
+        single_strengths.get(index, 0.0) for index in range(SINGLE_BLOCK_COUNT)
+    )
+    block_weights = _normalise_strengths(raw_strengths)
+
+    block_tensor_count = sum(len(pair) for pair in block_modules.values())
+    global_tensor_count = sum(len(pair) for pair in global_modules.values())
+    ready = not blockers
+
+    return {
+        "model_family": "Flux",
+        "lora_type": "Flux (PEFT base_model double+single blocks)",
+        "rank": next(iter(ranks)) if len(ranks) == 1 else None,
+        "rank_values": sorted(ranks),
+        "block_layout": EXPECTED_LAYOUT,
+        "block_count": len(block_weights),
+        "block_weights": block_weights,
+        "raw_block_strengths": raw_strengths,
+        "observed_double_indices": observed_double,
+        "observed_single_indices": observed_single,
+        "missing_double_indices": missing_double,
+        "missing_single_indices": missing_single,
+        "block_module_count": len(block_modules),
+        "block_tensor_count": block_tensor_count,
+        "global_module_count": len(global_modules),
+        "global_tensor_count": global_tensor_count,
+        "global_module_sample": global_module_names[:25],
+        "unmatched_tensor_count": len(unmatched_keys),
+        "unmatched_key_sample": unmatched_keys[:25],
+        "warnings": warnings,
+        "blockers": blockers,
+        "ready_for_controlled_apply": ready,
+    }
+
+
+def default_tensor_analyser(path: Path) -> Mapping[str, Any]:
+    from safetensors import safe_open
+
+    tensors: dict[str, torch.Tensor] = {}
+    with safe_open(str(path), framework="pt") as handle:
+        for key in handle.keys():
+            tensors[str(key)] = handle.get_tensor(key)
+    return analyse_peft_tensor_map(tensors)
+
+
+def _select_target(
+    diagnostics: Mapping[str, Any],
+    expected_stable_id: str,
+) -> dict[str, Any]:
+    if diagnostics.get("phase") != "8.9g-diagnostics":
+        raise PeftFluxAnalysisError("Phase 8.9j requires the Phase 8.9g diagnostics report")
+
+    matches = [
+        dict(target)
+        for target in diagnostics.get("targets", [])
+        if isinstance(target, Mapping)
+        and str(target.get("planned_stable_id") or "").upper()
+        == expected_stable_id.upper()
+    ]
+    if len(matches) != 1:
+        raise PeftFluxAnalysisError(
+            f"Expected exactly one diagnostics target for {expected_stable_id}, found {len(matches)}"
+        )
+    target = matches[0]
+    if target.get("ready_for_controlled_apply") is not False:
+        raise PeftFluxAnalysisError("Target is not in the expected blocked diagnostics state")
+    if target.get("tensor_inspection_error") is not None:
+        raise PeftFluxAnalysisError("Target tensor header is not readable")
+    if target.get("analysis_error") is None:
+        raise PeftFluxAnalysisError("Target does not contain the expected unsupported-analysis error")
+    return target
+
+
+def build_targeted_peft_analysis(
+    diagnostics: Mapping[str, Any],
+    *,
+    library_root: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    expected_stable_id: str = EXPECTED_STABLE_ID,
+    expected_source_sha256: str = EXPECTED_SOURCE_SHA256,
+    tensor_analyser: TensorAnalyser | None = None,
+) -> dict[str, Any]:
+    target = _select_target(diagnostics, expected_stable_id)
+    relative_path = str(target.get("relative_path") or "").strip()
+    if not relative_path:
+        raise PeftFluxAnalysisError("Diagnostics target has no relative_path")
+
+    root = Path(library_root).expanduser().resolve(strict=True)
+    source = _safe_source_path(root, relative_path)
+    source_sha256 = _sha256_file(source)
+    expected_source = str(expected_source_sha256 or "").strip().lower()
+    if source_sha256 != expected_source:
+        raise PeftFluxAnalysisError(
+            f"Source SHA-256 mismatch: expected {expected_source}, found {source_sha256}"
+        )
+    if source_sha256 != str(target.get("source_sha256") or "").lower():
+        raise PeftFluxAnalysisError("Source SHA-256 no longer matches Phase 8.9g diagnostics")
+
+    stable_id = str(target.get("planned_stable_id") or "").upper()
+    db_file_path = str(target.get("db_file_path") or "").strip()
+    if not db_file_path:
+        raise PeftFluxAnalysisError("Diagnostics target has no db_file_path")
+
+    conn = _open_read_only(db_path)
+    try:
+        integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
+        if integrity.casefold() != "ok":
+            raise PeftFluxAnalysisError(f"Database integrity check failed: {integrity}")
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE file_path = ?", (db_file_path,)
+        ).fetchone() is not None:
+            raise PeftFluxAnalysisError(f"Target file_path already exists in DB: {db_file_path}")
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE stable_id = ?", (stable_id,)
+        ).fetchone() is not None:
+            raise PeftFluxAnalysisError(f"Planned stable ID already exists in DB: {stable_id}")
+    finally:
+        conn.close()
+
+    analyser = tensor_analyser or default_tensor_analyser
+    analysis = dict(analyser(source))
+    if int(analysis.get("block_count") or 0) != TOTAL_BLOCK_COUNT:
+        raise PeftFluxAnalysisError(
+            f"Target analyser returned {analysis.get('block_count')} blocks, expected {TOTAL_BLOCK_COUNT}"
+        )
+    if analysis.get("block_layout") != EXPECTED_LAYOUT:
+        raise PeftFluxAnalysisError(
+            f"Target analyser returned layout {analysis.get('block_layout')!r}, expected {EXPECTED_LAYOUT!r}"
+        )
+
+    result: dict[str, Any] = {
+        "phase": "8.9j",
+        "mode": "read-only targeted PEFT Flux analysis",
+        "diagnostics_sha256": canonical_sha256(diagnostics),
+        "target": {
+            "relative_path": relative_path,
+            "db_file_path": db_file_path,
+            "filename": target.get("filename") or source.name,
+            "planned_stable_id": stable_id,
+            "base_model_name": target.get("base_model_name"),
+            "base_model_code": "FLX",
+            "category_name": target.get("category_name"),
+            "category_code": target.get("category_code"),
+            "source_size_bytes": source.stat().st_size,
+            "source_mtime": source.stat().st_mtime,
+            "source_sha256": source_sha256,
+            "tensor_key_count": target.get("tensor_key_count"),
+            "clip_contributor": target.get("clip_contributor"),
+            "clip_tensor_count": target.get("clip_tensor_count"),
+            **analysis,
+        },
+        "summary": {
+            "targets_analysed": 1,
+            "ready_for_controlled_apply": int(
+                analysis.get("ready_for_controlled_apply") is True
+            ),
+            "blocked_targets": int(
+                analysis.get("ready_for_controlled_apply") is not True
+            ),
+            "block_rows": int(analysis.get("block_count") or 0),
+            "global_projection_tensors": int(
+                analysis.get("global_tensor_count") or 0
+            ),
+        },
+        "safety": {
+            "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+            "writes_database": False,
+            "runs_full_indexer": False,
+            "discovers_library_files": False,
+            "opens_only_diagnostics_target": True,
+            "assigns_stable_ids": False,
+            "deletes_rows": False,
+            "touches_damaged_flux_target": False,
+        },
+    }
+    result["analysis_sha256"] = canonical_sha256(result)
+    return result
+
+
+def print_analysis(result: Mapping[str, Any]) -> None:
+    target = result["target"]
+    summary = result["summary"]
+    print("=== Phase 8.9j targeted PEFT Flux analysis ===")
+    print(f"Mode                       : {result['mode']}")
+    print(f"Analysis SHA-256           : {result['analysis_sha256']}")
+    print(f"Stable ID                  : {target['planned_stable_id']}")
+    print(f"Source SHA-256             : {target['source_sha256']}")
+    print(f"LoRA type                  : {target['lora_type']}")
+    print(f"Rank values                : {target['rank_values']}")
+    print(f"Observed double blocks     : {target['observed_double_indices']}")
+    print(f"Observed single blocks     : {target['observed_single_indices']}")
+    print(f"Block tensors              : {target['block_tensor_count']}")
+    print(f"Global projection tensors  : {target['global_tensor_count']}")
+    print(f"Block layout               : {target['block_layout']}")
+    print(f"Block rows                 : {target['block_count']}")
+    print(f"Ready for controlled apply : {bool(summary['ready_for_controlled_apply'])}")
+    for warning in target["warnings"]:
+        print(f"Warning                    : {warning}")
+    for blocker in target["blockers"]:
+        print(f"Blocker                    : {blocker}")
+    print("No database changes were made.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run a targeted read-only analyser for the PEFT-style FLX-STL-263 file"
+    )
+    parser.add_argument("--diagnostics", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--expected-stable-id", default=EXPECTED_STABLE_ID)
+    parser.add_argument("--expected-source-sha256", default=EXPECTED_SOURCE_SHA256)
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    result = build_targeted_peft_analysis(
+        load_json_object(args.diagnostics, "Diagnostics"),
+        library_root=args.root,
+        db_path=args.db,
+        expected_stable_id=args.expected_stable_id,
+        expected_source_sha256=args.expected_source_sha256,
+    )
+    verify_analysis_digest(result)
+    print_analysis(result)
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        print(f"JSON analysis written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/phase89j_targeted_peft_flux_analysis.py
+++ b/Database/backend/phase89j_targeted_peft_flux_analysis.py
@@ -6,14 +6,12 @@ import json
 import math
 import os
 import re
-import sqlite3
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
 import torch
 
 from phase89g_targeted_flux_analysis import (
-    FluxAnalysisPlanError,
     _open_read_only,
     _safe_source_path,
     _sha256_file,
@@ -32,6 +30,19 @@ EXPECTED_LAYOUT = "flux_unet_57"
 DOUBLE_BLOCK_COUNT = 19
 SINGLE_BLOCK_COUNT = 38
 TOTAL_BLOCK_COUNT = DOUBLE_BLOCK_COUNT + SINGLE_BLOCK_COUNT
+
+ALLOWED_GLOBAL_ROOTS = frozenset(
+    {
+        "guidance_in",
+        "time_in",
+        "double_stream_modulation_img",
+        "double_stream_modulation_txt",
+        "final_layer",
+        "img_in",
+        "single_stream_modulation",
+        "txt_in",
+    }
+)
 
 _BLOCK_KEY_RE = re.compile(
     r"^base_model\.model\.(double_blocks|single_blocks)\.(\d+)\."
@@ -148,6 +159,10 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
         global_match = _GLOBAL_KEY_RE.match(name)
         if global_match:
             module = global_match.group(1)
+            root = module.split(".", 1)[0].casefold()
+            if root not in ALLOWED_GLOBAL_ROOTS:
+                unmatched_keys.append(name)
+                continue
             side = global_match.group(2).lower()
             pair = global_modules.setdefault(module, {})
             if side in pair:
@@ -166,7 +181,11 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
     single_strengths: dict[int, float] = {}
 
     for (stream, index, module), pair in sorted(block_modules.items()):
-        max_index = DOUBLE_BLOCK_COUNT - 1 if stream == "double_blocks" else SINGLE_BLOCK_COUNT - 1
+        max_index = (
+            DOUBLE_BLOCK_COUNT - 1
+            if stream == "double_blocks"
+            else SINGLE_BLOCK_COUNT - 1
+        )
         if index < 0 or index > max_index:
             blockers.append(
                 f"Out-of-range {stream} index {index}; supported range is 0..{max_index}"
@@ -179,7 +198,9 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
 
         if "a" in pair and "b" in pair:
             strength = _tensor_norm(pair["a"]) + _tensor_norm(pair["b"])
-            bucket = double_strengths if stream == "double_blocks" else single_strengths
+            bucket = (
+                double_strengths if stream == "double_blocks" else single_strengths
+            )
             bucket[index] = bucket.get(index, 0.0) + strength
 
     global_module_names: list[str] = []
@@ -193,7 +214,9 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
         if "b" in pair:
             _tensor_norm(pair["b"])
 
-    unmatched_lora_keys = [key for key in unmatched_keys if "lora_" in key.casefold()]
+    unmatched_lora_keys = [
+        key for key in unmatched_keys if "lora_" in key.casefold()
+    ]
     if unmatched_lora_keys:
         blockers.append(
             f"Found {len(unmatched_lora_keys)} unrecognised LoRA tensor key(s)"
@@ -206,8 +229,12 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
     if not observed_single:
         blockers.append("No base_model.model.single_blocks LoRA pairs were found")
 
-    missing_double = [index for index in range(DOUBLE_BLOCK_COUNT) if index not in double_strengths]
-    missing_single = [index for index in range(SINGLE_BLOCK_COUNT) if index not in single_strengths]
+    missing_double = [
+        index for index in range(DOUBLE_BLOCK_COUNT) if index not in double_strengths
+    ]
+    missing_single = [
+        index for index in range(SINGLE_BLOCK_COUNT) if index not in single_strengths
+    ]
     if missing_double or missing_single:
         warnings.append(
             "Unadapted Flux blocks are represented as zero strength in the 57-block layout"
@@ -219,7 +246,9 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
     if len(ranks) > 1:
         warnings.append("The file uses more than one LoRA rank across adapted modules")
 
-    raw_strengths = [double_strengths.get(index, 0.0) for index in range(DOUBLE_BLOCK_COUNT)]
+    raw_strengths = [
+        double_strengths.get(index, 0.0) for index in range(DOUBLE_BLOCK_COUNT)
+    ]
     raw_strengths.extend(
         single_strengths.get(index, 0.0) for index in range(SINGLE_BLOCK_COUNT)
     )
@@ -230,6 +259,7 @@ def analyse_peft_tensor_map(tensors: Mapping[str, torch.Tensor]) -> dict[str, An
     ready = not blockers
 
     return {
+        "tensor_key_count": len(tensors),
         "model_family": "Flux",
         "lora_type": "Flux (PEFT base_model double+single blocks)",
         "rank": next(iter(ranks)) if len(ranks) == 1 else None,
@@ -270,7 +300,9 @@ def _select_target(
     expected_stable_id: str,
 ) -> dict[str, Any]:
     if diagnostics.get("phase") != "8.9g-diagnostics":
-        raise PeftFluxAnalysisError("Phase 8.9j requires the Phase 8.9g diagnostics report")
+        raise PeftFluxAnalysisError(
+            "Phase 8.9j requires the Phase 8.9g diagnostics report"
+        )
 
     matches = [
         dict(target)
@@ -281,15 +313,20 @@ def _select_target(
     ]
     if len(matches) != 1:
         raise PeftFluxAnalysisError(
-            f"Expected exactly one diagnostics target for {expected_stable_id}, found {len(matches)}"
+            f"Expected exactly one diagnostics target for {expected_stable_id}, "
+            f"found {len(matches)}"
         )
     target = matches[0]
     if target.get("ready_for_controlled_apply") is not False:
-        raise PeftFluxAnalysisError("Target is not in the expected blocked diagnostics state")
+        raise PeftFluxAnalysisError(
+            "Target is not in the expected blocked diagnostics state"
+        )
     if target.get("tensor_inspection_error") is not None:
         raise PeftFluxAnalysisError("Target tensor header is not readable")
     if target.get("analysis_error") is None:
-        raise PeftFluxAnalysisError("Target does not contain the expected unsupported-analysis error")
+        raise PeftFluxAnalysisError(
+            "Target does not contain the expected unsupported-analysis error"
+        )
     return target
 
 
@@ -316,7 +353,9 @@ def build_targeted_peft_analysis(
             f"Source SHA-256 mismatch: expected {expected_source}, found {source_sha256}"
         )
     if source_sha256 != str(target.get("source_sha256") or "").lower():
-        raise PeftFluxAnalysisError("Source SHA-256 no longer matches Phase 8.9g diagnostics")
+        raise PeftFluxAnalysisError(
+            "Source SHA-256 no longer matches Phase 8.9g diagnostics"
+        )
 
     stable_id = str(target.get("planned_stable_id") or "").upper()
     db_file_path = str(target.get("db_file_path") or "").strip()
@@ -327,27 +366,43 @@ def build_targeted_peft_analysis(
     try:
         integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
         if integrity.casefold() != "ok":
-            raise PeftFluxAnalysisError(f"Database integrity check failed: {integrity}")
+            raise PeftFluxAnalysisError(
+                f"Database integrity check failed: {integrity}"
+            )
         if conn.execute(
             "SELECT 1 FROM lora WHERE file_path = ?", (db_file_path,)
         ).fetchone() is not None:
-            raise PeftFluxAnalysisError(f"Target file_path already exists in DB: {db_file_path}")
+            raise PeftFluxAnalysisError(
+                f"Target file_path already exists in DB: {db_file_path}"
+            )
         if conn.execute(
             "SELECT 1 FROM lora WHERE stable_id = ?", (stable_id,)
         ).fetchone() is not None:
-            raise PeftFluxAnalysisError(f"Planned stable ID already exists in DB: {stable_id}")
+            raise PeftFluxAnalysisError(
+                f"Planned stable ID already exists in DB: {stable_id}"
+            )
     finally:
         conn.close()
 
     analyser = tensor_analyser or default_tensor_analyser
     analysis = dict(analyser(source))
+    if int(analysis.get("tensor_key_count") or 0) != int(
+        target.get("tensor_key_count") or 0
+    ):
+        raise PeftFluxAnalysisError(
+            "Tensor-key count no longer matches Phase 8.9g diagnostics: "
+            f"expected {target.get('tensor_key_count')}, "
+            f"found {analysis.get('tensor_key_count')}"
+        )
     if int(analysis.get("block_count") or 0) != TOTAL_BLOCK_COUNT:
         raise PeftFluxAnalysisError(
-            f"Target analyser returned {analysis.get('block_count')} blocks, expected {TOTAL_BLOCK_COUNT}"
+            f"Target analyser returned {analysis.get('block_count')} blocks, "
+            f"expected {TOTAL_BLOCK_COUNT}"
         )
     if analysis.get("block_layout") != EXPECTED_LAYOUT:
         raise PeftFluxAnalysisError(
-            f"Target analyser returned layout {analysis.get('block_layout')!r}, expected {EXPECTED_LAYOUT!r}"
+            f"Target analyser returned layout {analysis.get('block_layout')!r}, "
+            f"expected {EXPECTED_LAYOUT!r}"
         )
 
     result: dict[str, Any] = {
@@ -366,7 +421,6 @@ def build_targeted_peft_analysis(
             "source_size_bytes": source.stat().st_size,
             "source_mtime": source.stat().st_mtime,
             "source_sha256": source_sha256,
-            "tensor_key_count": target.get("tensor_key_count"),
             "clip_contributor": target.get("clip_contributor"),
             "clip_tensor_count": target.get("clip_tensor_count"),
             **analysis,
@@ -385,7 +439,9 @@ def build_targeted_peft_analysis(
             ),
         },
         "safety": {
-            "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+            "database_open_mode": (
+                "SQLite URI mode=ro plus PRAGMA query_only=ON"
+            ),
             "writes_database": False,
             "runs_full_indexer": False,
             "discovers_library_files": False,
@@ -407,15 +463,20 @@ def print_analysis(result: Mapping[str, Any]) -> None:
     print(f"Analysis SHA-256           : {result['analysis_sha256']}")
     print(f"Stable ID                  : {target['planned_stable_id']}")
     print(f"Source SHA-256             : {target['source_sha256']}")
+    print(f"Tensor keys                : {target['tensor_key_count']}")
     print(f"LoRA type                  : {target['lora_type']}")
     print(f"Rank values                : {target['rank_values']}")
     print(f"Observed double blocks     : {target['observed_double_indices']}")
     print(f"Observed single blocks     : {target['observed_single_indices']}")
     print(f"Block tensors              : {target['block_tensor_count']}")
     print(f"Global projection tensors  : {target['global_tensor_count']}")
+    print(f"Unmatched tensors          : {target['unmatched_tensor_count']}")
     print(f"Block layout               : {target['block_layout']}")
     print(f"Block rows                 : {target['block_count']}")
-    print(f"Ready for controlled apply : {bool(summary['ready_for_controlled_apply'])}")
+    print(
+        "Ready for controlled apply : "
+        f"{bool(summary['ready_for_controlled_apply'])}"
+    )
     for warning in target["warnings"]:
         print(f"Warning                    : {warning}")
     for blocker in target["blockers"]:
@@ -425,13 +486,18 @@ def print_analysis(result: Mapping[str, Any]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run a targeted read-only analyser for the PEFT-style FLX-STL-263 file"
+        description=(
+            "Run a targeted read-only analyser for the PEFT-style "
+            "FLX-STL-263 file"
+        )
     )
     parser.add_argument("--diagnostics", required=True)
     parser.add_argument("--root", required=True)
     parser.add_argument("--db", required=True)
     parser.add_argument("--expected-stable-id", default=EXPECTED_STABLE_ID)
-    parser.add_argument("--expected-source-sha256", default=EXPECTED_SOURCE_SHA256)
+    parser.add_argument(
+        "--expected-source-sha256", default=EXPECTED_SOURCE_SHA256
+    )
     parser.add_argument("--json")
     args = parser.parse_args()
 

--- a/Database/backend/tests/test_phase89j_targeted_peft_flux_analysis.py
+++ b/Database/backend/tests/test_phase89j_targeted_peft_flux_analysis.py
@@ -3,10 +3,33 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 import sys
+import types
 from pathlib import Path
 
 import pytest
-import torch
+
+
+class _FakeScalar:
+    def __init__(self, value: float) -> None:
+        self._value = float(value)
+
+    def item(self) -> float:
+        return self._value
+
+
+class FakeTensor:
+    def __init__(self, shape: tuple[int, ...], norm_value: float = 1.0) -> None:
+        self.shape = tuple(shape)
+        self.ndim = len(self.shape)
+        self._norm_value = float(norm_value)
+
+    def norm(self) -> _FakeScalar:
+        return _FakeScalar(self._norm_value)
+
+
+fake_torch = types.ModuleType("torch")
+fake_torch.Tensor = FakeTensor
+sys.modules.setdefault("torch", fake_torch)
 
 BACKEND = Path(__file__).resolve().parents[1]
 if str(BACKEND) not in sys.path:
@@ -104,15 +127,15 @@ def _diagnostics(source_sha: str) -> dict[str, object]:
     }
 
 
-def _pair(prefix: str, rank: int = 2) -> dict[str, torch.Tensor]:
+def _pair(prefix: str, rank: int = 2) -> dict[str, FakeTensor]:
     return {
-        f"{prefix}.lora_A.weight": torch.ones((rank, 4), dtype=torch.float32),
-        f"{prefix}.lora_B.weight": torch.ones((6, rank), dtype=torch.float32),
+        f"{prefix}.lora_A.weight": FakeTensor((rank, 4)),
+        f"{prefix}.lora_B.weight": FakeTensor((6, rank)),
     }
 
 
-def _valid_tensors() -> dict[str, torch.Tensor]:
-    tensors: dict[str, torch.Tensor] = {}
+def _valid_tensors() -> dict[str, FakeTensor]:
+    tensors: dict[str, FakeTensor] = {}
     tensors.update(
         _pair("base_model.model.double_blocks.0.img_attn.proj")
     )

--- a/Database/backend/tests/test_phase89j_targeted_peft_flux_analysis.py
+++ b/Database/backend/tests/test_phase89j_targeted_peft_flux_analysis.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+BACKEND = Path(__file__).resolve().parents[1]
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from phase89j_targeted_peft_flux_analysis import (
+    EXPECTED_SOURCE_SHA256,
+    EXPECTED_STABLE_ID,
+    PeftFluxAnalysisError,
+    analyse_peft_tensor_map,
+    build_targeted_peft_analysis,
+    verify_analysis_digest,
+)
+
+
+RELATIVE_PATH = "FLUX/02 - Styles/aidmaMJ61Flux.2v0.5.safetensors"
+DB_FILE_PATH = f"/loras/{RELATIVE_PATH}"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source(root: Path, payload: bytes = b"phase89j-target") -> Path:
+    path = root / Path(*RELATIVE_PATH.split("/"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return path
+
+
+def _db(path: Path, *, collision: bool = False) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            stable_id TEXT
+        )
+        """
+    )
+    if collision:
+        conn.execute(
+            "INSERT INTO lora (file_path, stable_id) VALUES (?, ?)",
+            ("/loras/existing.safetensors", EXPECTED_STABLE_ID),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _diagnostics(source_sha: str) -> dict[str, object]:
+    return {
+        "phase": "8.9g-diagnostics",
+        "plan_sha256": "plan-digest",
+        "summary": {
+            "flux_candidates": 3,
+            "ready_for_controlled_apply": 1,
+            "blocked_candidates": 2,
+        },
+        "targets": [
+            {
+                "relative_path": "FLUX/01 - People/ready.safetensors",
+                "planned_stable_id": "FLX-PPL-207",
+                "ready_for_controlled_apply": True,
+            },
+            {
+                "relative_path": RELATIVE_PATH,
+                "db_file_path": DB_FILE_PATH,
+                "filename": Path(RELATIVE_PATH).name,
+                "planned_stable_id": EXPECTED_STABLE_ID,
+                "base_model_name": "Flux",
+                "base_model_code": "FLX",
+                "category_name": "Styles",
+                "category_code": "STL",
+                "source_sha256": source_sha,
+                "tensor_key_count": 12,
+                "clip_contributor": False,
+                "clip_tensor_count": 0,
+                "tensor_inspection_error": None,
+                "analysis_error": {
+                    "type": "ValueError",
+                    "message": "No UNet-style keys found in safetensors file.",
+                },
+                "ready_for_controlled_apply": False,
+            },
+            {
+                "relative_path": "FLUX/05 - Body/broken.safetensors",
+                "planned_stable_id": "FLX-BDY-071",
+                "tensor_inspection_error": {"type": "SafetensorError"},
+                "ready_for_controlled_apply": False,
+            },
+        ],
+        "safety": {"writes_database": False},
+    }
+
+
+def _pair(prefix: str, rank: int = 2) -> dict[str, torch.Tensor]:
+    return {
+        f"{prefix}.lora_A.weight": torch.ones((rank, 4), dtype=torch.float32),
+        f"{prefix}.lora_B.weight": torch.ones((6, rank), dtype=torch.float32),
+    }
+
+
+def _valid_tensors() -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    tensors.update(
+        _pair("base_model.model.double_blocks.0.img_attn.proj")
+    )
+    tensors.update(
+        _pair("base_model.model.double_blocks.18.txt_attn.qkv")
+    )
+    tensors.update(
+        _pair("base_model.model.single_blocks.0.linear1")
+    )
+    tensors.update(
+        _pair("base_model.model.single_blocks.37.linear2")
+    )
+    tensors.update(_pair("base_model.model.time_in.in_layer"))
+    tensors.update(_pair("base_model.model.final_layer.linear"))
+    return tensors
+
+
+def test_valid_peft_namespace_maps_to_57_blocks_and_preserves_db(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    diagnostics = _diagnostics(_sha256(source))
+    before = db.read_bytes()
+
+    result = build_targeted_peft_analysis(
+        diagnostics,
+        library_root=root,
+        db_path=db,
+        expected_source_sha256=_sha256(source),
+        tensor_analyser=lambda _: analyse_peft_tensor_map(_valid_tensors()),
+    )
+
+    target = result["target"]
+    assert result["phase"] == "8.9j"
+    assert target["planned_stable_id"] == EXPECTED_STABLE_ID
+    assert target["block_layout"] == "flux_unet_57"
+    assert target["block_count"] == 57
+    assert len(target["block_weights"]) == 57
+    assert len(target["raw_block_strengths"]) == 57
+    assert target["observed_double_indices"] == [0, 18]
+    assert target["observed_single_indices"] == [0, 37]
+    assert target["rank"] == 2
+    assert target["rank_values"] == [2]
+    assert target["global_tensor_count"] == 4
+    assert target["ready_for_controlled_apply"] is True
+    assert target["blockers"] == []
+    assert verify_analysis_digest(result) == result["analysis_sha256"]
+    assert db.read_bytes() == before
+
+
+def test_incomplete_lora_pair_is_blocked() -> None:
+    tensors = _valid_tensors()
+    tensors.pop(
+        "base_model.model.single_blocks.37.linear2.lora_B.weight"
+    )
+
+    result = analyse_peft_tensor_map(tensors)
+
+    assert result["ready_for_controlled_apply"] is False
+    assert any("Incomplete LoRA pair" in item for item in result["blockers"])
+
+
+def test_out_of_range_block_index_is_blocked() -> None:
+    tensors = _valid_tensors()
+    tensors.update(
+        _pair("base_model.model.double_blocks.19.img_attn.proj")
+    )
+
+    result = analyse_peft_tensor_map(tensors)
+
+    assert result["ready_for_controlled_apply"] is False
+    assert any("Out-of-range double_blocks index 19" in item for item in result["blockers"])
+
+
+def test_unrecognised_lora_namespace_is_blocked() -> None:
+    tensors = _valid_tensors()
+    tensors.update(_pair("base_model.model.weird_blocks.0.linear"))
+
+    result = analyse_peft_tensor_map(tensors)
+
+    assert result["ready_for_controlled_apply"] is False
+    assert any("unrecognised LoRA tensor" in item for item in result["blockers"])
+
+
+def test_source_hash_drift_is_rejected_before_tensor_analysis(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    diagnostics = _diagnostics(_sha256(source))
+    source.write_bytes(b"changed-after-diagnostics")
+
+    called = False
+
+    def analyser(_: Path) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {}
+
+    with pytest.raises(PeftFluxAnalysisError, match="Source SHA-256 mismatch"):
+        build_targeted_peft_analysis(
+            diagnostics,
+            library_root=root,
+            db_path=db,
+            expected_source_sha256="0" * 64,
+            tensor_analyser=analyser,
+        )
+
+    assert called is False
+
+
+def test_existing_stable_id_collision_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db", collision=True)
+    diagnostics = _diagnostics(_sha256(source))
+
+    with pytest.raises(PeftFluxAnalysisError, match="Planned stable ID already exists"):
+        build_targeted_peft_analysis(
+            diagnostics,
+            library_root=root,
+            db_path=db,
+            expected_source_sha256=_sha256(source),
+            tensor_analyser=lambda _: analyse_peft_tensor_map(_valid_tensors()),
+        )

--- a/docs/phase89j-targeted-peft-flux-analysis.md
+++ b/docs/phase89j-targeted-peft-flux-analysis.md
@@ -1,0 +1,101 @@
+# Phase 8.9j targeted PEFT Flux analysis
+
+Phase 8.9j adds a read-only analyser for the single remaining valid FLX candidate that Phase 8.9g could not interpret:
+
+- path: `FLUX/02 - Styles/aidmaMJ61Flux.2v0.5.safetensors`
+- planned stable ID: `FLX-STL-263`
+- source SHA-256: `c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7`
+- observed namespace: `base_model.model.double_blocks.*` and `base_model.model.single_blocks.*`
+
+The damaged `FLX-BDY-071` source is explicitly excluded.
+
+## Purpose
+
+The existing Delta Inspector recognises Flux keys such as:
+
+- `lora_unet_double_blocks_<idx>_*`
+- `lora_unet_single_blocks_<idx>_*`
+- `transformer.single_transformer_blocks.<idx>.*`
+
+`FLX-STL-263` instead uses paired PEFT tensors:
+
+- `base_model.model.double_blocks.<idx>.<module>.lora_A.weight`
+- `base_model.model.double_blocks.<idx>.<module>.lora_B.weight`
+- `base_model.model.single_blocks.<idx>.<module>.lora_A.weight`
+- `base_model.model.single_blocks.<idx>.<module>.lora_B.weight`
+
+Phase 8.9j analyses only that target and does not change the general indexer or database.
+
+## Analysis rules
+
+The analyser:
+
+- requires the exact Phase 8.9g blocked target and stable ID
+- requires the exact source SHA-256
+- opens SQLite with URI `mode=ro` and `PRAGMA query_only = ON`
+- confirms the target path and stable ID remain absent
+- requires the tensor-key count to match Phase 8.9g diagnostics
+- validates every LoRA A/B pair
+- validates two-dimensional tensor shapes and matching ranks
+- accepts double-block indices only in `0..18`
+- accepts single-block indices only in `0..37`
+- maps missing, unadapted blocks to zero strength
+- computes ordered `DOUBLE_0..18 + SINGLE_0..37` strengths
+- emits layout `flux_unet_57`
+- records known global projection tensors separately
+- blocks unknown `base_model.model.*` LoRA namespaces
+- records a canonical analysis SHA-256
+
+Known global roots are limited to:
+
+- `guidance_in`
+- `time_in`
+- `double_stream_modulation_img`
+- `double_stream_modulation_txt`
+- `final_layer`
+- `img_in`
+- `single_stream_modulation`
+- `txt_in`
+
+These tensors are validated but excluded from per-block strengths.
+
+## Safety boundary
+
+- no database writes
+- no backup creation
+- no full indexer invocation
+- no library enumeration
+- only the exact diagnostics target is opened
+- no stable-ID assignment
+- no relocation, stale-row or legacy-row work
+- no access to the damaged FLX file
+
+## Bender validation
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89j_targeted_peft_flux_analysis.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89j_targeted_peft_flux_analysis.py
+```
+
+Expected: 6 tests passed and silent compilation.
+
+## Planned Nibbler run
+
+After review and merge, run inside a temporary backend container:
+
+```bash
+sudo docker compose --env-file .env run --rm --no-deps -T backend \
+  python phase89j_targeted_peft_flux_analysis.py \
+  --diagnostics /data/phase89g_flux_diagnostics.json \
+  --root /loras \
+  --db /data/lora_master.db \
+  --expected-stable-id FLX-STL-263 \
+  --expected-source-sha256 c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7 \
+  --json /data/phase89j_flx_stl_263_analysis.json
+```
+
+The database SHA-256 must be identical before and after the run.


### PR DESCRIPTION
## What changed

- Added a read-only Phase 8.9j analyser for the single blocked target `FLX-STL-263`.
- Supports the observed PEFT namespace `base_model.model.double_blocks.*` / `single_blocks.*` without changing the general indexer.
- Validates exact source SHA-256, Phase 8.9g tensor count, path absence, stable-ID availability and SQLite integrity.
- Requires complete LoRA A/B pairs, two-dimensional shapes and matching ranks.
- Accepts standard Flux ranges only: double blocks `0..18`, single blocks `0..37`.
- Computes the ordered 57-block layout, representing unadapted blocks as zero strength.
- Records known global projection tensors separately and blocks unknown `base_model.model.*` LoRA namespaces.
- Emits a canonical analysis SHA-256 for a later sealed step.
- Explicitly excludes the damaged `FLX-BDY-071` source.
- Added focused tests and an operational runbook.

## Safety boundary

- SQLite URI `mode=ro` plus `PRAGMA query_only = ON`.
- No inserts, updates, deletes, backups or stable-ID assignments.
- No full indexer invocation or library enumeration.
- Opens only the diagnostics-approved `FLX-STL-263` source.
- Does not modify `delta_inspector_engine.py` yet.

## Validation

Verified on Bender from the repository root:

```text
6 passed in 0.09s
python -m py_compile: passed silently
```

The first Bender run stopped during test collection because Bender's lightweight Python environment does not include PyTorch. Follow-up commit `5eb46d9` replaced the test-only tensors with a minimal fake tensor implementation while leaving the production analyser unchanged. Nibbler's backend container will use real PyTorch tensors for the live read-only analysis.