### PR TITLE
Phase 8.9k: add Flux 2 56-block layout support

### DIFF
--- a/Database/backend/block_layouts.py
+++ b/Database/backend/block_layouts.py
@@ -6,6 +6,7 @@ from typing import Optional
 FLUX_FALLBACK_16 = "flux_fallback_16"
 UNET_57 = "unet_57"
 FLUX_UNET_57 = "flux_unet_57"
+FLUX2_TRANSFORMER_56 = "flux2_transformer_56"
 FALLBACK_LAYOUTS = {FLUX_FALLBACK_16, UNET_57, FLUX_UNET_57}
 
 _FLUX_TRANSFORMER_RE = re.compile(r"^flux_transformer_(\d+)$")
@@ -18,6 +19,8 @@ _WAN_MODE_UNET_RE = re.compile(r"^wan_([a-z0-9]+)_unet_(\d+)$")
 def _extract_count(layout: str) -> Optional[int]:
     if layout == FLUX_FALLBACK_16:
         return 16
+    if layout == FLUX2_TRANSFORMER_56:
+        return 56
     if layout in {UNET_57, FLUX_UNET_57}:
         return 57
 
@@ -44,7 +47,12 @@ def normalize_block_layout(raw: Optional[str]) -> Optional[str]:
     if not value:
         return None
 
-    if value in {FLUX_FALLBACK_16, UNET_57, FLUX_UNET_57}:
+    if value in {
+        FLUX_FALLBACK_16,
+        UNET_57,
+        FLUX_UNET_57,
+        FLUX2_TRANSFORMER_56,
+    }:
         return value
 
     if (
@@ -76,6 +84,8 @@ def fallback_block_count_for_layout(layout: Optional[str]) -> Optional[int]:
 def infer_layout_from_block_count(block_count: int) -> Optional[str]:
     if block_count == 57:
         return UNET_57
+    if block_count == 56:
+        return FLUX2_TRANSFORMER_56
     if block_count == 16:
         return FLUX_FALLBACK_16
     return None
@@ -87,16 +97,22 @@ def make_flux_layout(lora_type: Optional[str], block_count: int) -> Optional[str
 
     lora_type_norm = (lora_type or "").lower()
 
+    if (
+        "flux 2" in lora_type_norm
+        or "flux2" in lora_type_norm
+    ) and block_count == 56:
+        return FLUX2_TRANSFORMER_56
+
     if "single_transformer_blocks" in lora_type_norm:
         return f"flux_transformer_{block_count}"
+
     # Handle inspector label: "Flux (UNet double+single blocks)"
     if "unet double+single blocks" in lora_type_norm or "double+single" in lora_type_norm:
         if block_count == 57:
             return FLUX_UNET_57
-        else:
-            return None
+        return None
 
-# Handle legacy/double block wording
+    # Handle legacy/double block wording
     if "unet double_blocks" in lora_type_norm or "double_blocks" in lora_type_norm:
         return f"flux_double_{block_count}"
 
@@ -110,6 +126,8 @@ def _self_test() -> None:
     samples = [
         "flux_fallback_16",
         "UNET_57",
+        "flux_unet_57",
+        "flux2_transformer_56",
         "flux_transformer_38",
         "flux_double_19",
         "flux_te_24",
@@ -125,9 +143,11 @@ def _self_test() -> None:
         print(f"raw={raw!r} -> normalized={normalized!r}, expected_count={expected!r}")
 
     print("Infer 57:", infer_layout_from_block_count(57))
+    print("Infer 56:", infer_layout_from_block_count(56))
     print("Infer 16:", infer_layout_from_block_count(16))
     print("Infer 38:", infer_layout_from_block_count(38))
     print("Flux layout from type:", make_flux_layout("Flux (single_transformer_blocks)", 38))
+    print("Flux 2 layout from type:", make_flux_layout("Flux 2 (PEFT double+single blocks)", 56))
 
 
 if __name__ == "__main__":

--- a/Database/backend/phase89k_flux2_layout_support.py
+++ b/Database/backend/phase89k_flux2_layout_support.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from block_layouts import FLUX2_TRANSFORMER_56, expected_block_count_for_layout
+from phase89g_targeted_flux_analysis import (
+    _open_read_only,
+    _safe_source_path,
+    _sha256_file,
+)
+
+
+class Flux2LayoutError(RuntimeError):
+    pass
+
+
+EXPECTED_STABLE_ID = "FLX-STL-263"
+EXPECTED_SOURCE_SHA256 = (
+    "c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7"
+)
+EXPECTED_PHASE89J_SHA256 = (
+    "7c886a07e87fa36081645d34bd578001420e65a380c6543b17c9b9ee1fb8dc48"
+)
+EXPECTED_TENSOR_KEY_COUNT = 276
+EXPECTED_RANK = 16
+DOUBLE_BLOCK_COUNT = 8
+SINGLE_BLOCK_COUNT = 48
+TOTAL_BLOCK_COUNT = DOUBLE_BLOCK_COUNT + SINGLE_BLOCK_COUNT
+EXPECTED_BLOCK_MODULE_COUNT = 128
+EXPECTED_BLOCK_TENSOR_COUNT = 256
+EXPECTED_GLOBAL_MODULE_COUNT = 10
+EXPECTED_GLOBAL_TENSOR_COUNT = 20
+
+EXPECTED_GLOBAL_MODULES = (
+    "double_stream_modulation_img.lin",
+    "double_stream_modulation_txt.lin",
+    "final_layer.linear",
+    "guidance_in.in_layer",
+    "guidance_in.out_layer",
+    "img_in",
+    "single_stream_modulation.lin",
+    "time_in.in_layer",
+    "time_in.out_layer",
+    "txt_in",
+)
+
+ALLOWED_GLOBAL_ROOTS = frozenset(
+    {
+        "guidance_in",
+        "time_in",
+        "double_stream_modulation_img",
+        "double_stream_modulation_txt",
+        "final_layer",
+        "img_in",
+        "single_stream_modulation",
+        "txt_in",
+    }
+)
+
+_BLOCK_KEY_RE = re.compile(
+    r"^base_model\.model\.(double_blocks|single_blocks)\.(\d+)\."
+    r"(.+)\.lora_([ab])\.weight$",
+    re.IGNORECASE,
+)
+_GLOBAL_KEY_RE = re.compile(
+    r"^base_model\.model\.(?!double_blocks\.|single_blocks\.)(.+)\."
+    r"lora_([ab])\.weight$",
+    re.IGNORECASE,
+)
+_PHASE89J_RANGE_BLOCKER_RE = re.compile(
+    r"^Out-of-range single_blocks index (\d+); supported range is 0\.\.37$"
+)
+
+TensorAnalyser = Callable[[Path], Mapping[str, Any]]
+
+
+def load_json_object(path: str | os.PathLike[str], label: str) -> dict[str, Any]:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    with resolved.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise Flux2LayoutError(f"{label} JSON must contain an object")
+    return value
+
+
+def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _verify_embedded_digest(
+    value: Mapping[str, Any],
+    field: str,
+    label: str,
+) -> str:
+    stored = str(value.get(field) or "")
+    unsigned = dict(value)
+    unsigned.pop(field, None)
+    calculated = canonical_sha256(unsigned)
+    if stored != calculated:
+        raise Flux2LayoutError(
+            f"{label} digest mismatch: stored {stored}, calculated {calculated}"
+        )
+    return calculated
+
+
+def verify_artifact_digest(artifact: Mapping[str, Any]) -> str:
+    return _verify_embedded_digest(
+        artifact,
+        "artifact_sha256",
+        "Phase 8.9k artifact",
+    )
+
+
+def _tensor_norm(value: Any) -> float:
+    norm = float(value.norm().item())
+    if not math.isfinite(norm):
+        raise Flux2LayoutError("Encountered non-finite tensor norm")
+    return norm
+
+
+def _pair_rank(
+    module_name: str,
+    pair: Mapping[str, Any],
+    blockers: list[str],
+) -> int | None:
+    a = pair.get("a")
+    b = pair.get("b")
+    if a is None or b is None:
+        missing = "A" if a is None else "B"
+        blockers.append(
+            f"Incomplete LoRA pair for {module_name}: missing lora_{missing}"
+        )
+        return None
+    if int(a.ndim) != 2 or int(b.ndim) != 2:
+        blockers.append(
+            f"LoRA pair for {module_name} is not two-dimensional: "
+            f"A{tuple(a.shape)}, B{tuple(b.shape)}"
+        )
+        return None
+    rank_a = int(a.shape[0])
+    rank_b = int(b.shape[1])
+    if rank_a <= 0 or rank_b <= 0 or rank_a != rank_b:
+        blockers.append(
+            f"LoRA rank mismatch for {module_name}: "
+            f"A rank {rank_a}, B rank {rank_b}"
+        )
+        return None
+    return rank_a
+
+
+def _normalise_strengths(raw_strengths: list[float]) -> list[float]:
+    maximum = max(raw_strengths, default=0.0)
+    if maximum <= 0:
+        return [0.0 for _ in raw_strengths]
+    return [round(value / maximum, 6) for value in raw_strengths]
+
+
+def _append_unique(items: list[str], value: str) -> None:
+    if value not in items:
+        items.append(value)
+
+
+def analyse_flux2_tensor_map(tensors: Mapping[str, Any]) -> dict[str, Any]:
+    block_modules: dict[tuple[str, int, str], dict[str, Any]] = {}
+    global_modules: dict[str, dict[str, Any]] = {}
+    unmatched_keys: list[str] = []
+
+    for raw_name, tensor in sorted(
+        tensors.items(),
+        key=lambda item: str(item[0]).casefold(),
+    ):
+        name = str(raw_name)
+        block_match = _BLOCK_KEY_RE.match(name)
+        if block_match:
+            stream = block_match.group(1).lower()
+            index = int(block_match.group(2))
+            module = block_match.group(3)
+            side = block_match.group(4).lower()
+            key = (stream, index, module)
+            pair = block_modules.setdefault(key, {})
+            if side in pair:
+                raise Flux2LayoutError(
+                    f"Duplicate lora_{side.upper()} tensor for "
+                    f"{stream}.{index}.{module}"
+                )
+            pair[side] = tensor
+            continue
+
+        global_match = _GLOBAL_KEY_RE.match(name)
+        if global_match:
+            module = global_match.group(1)
+            root = module.split(".", 1)[0].casefold()
+            if root not in ALLOWED_GLOBAL_ROOTS:
+                unmatched_keys.append(name)
+                continue
+            side = global_match.group(2).lower()
+            pair = global_modules.setdefault(module, {})
+            if side in pair:
+                raise Flux2LayoutError(
+                    f"Duplicate lora_{side.upper()} tensor for global module {module}"
+                )
+            pair[side] = tensor
+            continue
+
+        unmatched_keys.append(name)
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    ranks: set[int] = set()
+    double_strengths: dict[int, float] = {}
+    single_strengths: dict[int, float] = {}
+
+    for (stream, index, module), pair in sorted(block_modules.items()):
+        max_index = (
+            DOUBLE_BLOCK_COUNT - 1
+            if stream == "double_blocks"
+            else SINGLE_BLOCK_COUNT - 1
+        )
+        if index < 0 or index > max_index:
+            _append_unique(
+                blockers,
+                f"Out-of-range {stream} index {index}; "
+                f"supported range is 0..{max_index}",
+            )
+
+        module_name = f"{stream}.{index}.{module}"
+        rank = _pair_rank(module_name, pair, blockers)
+        if rank is not None:
+            ranks.add(rank)
+
+        if "a" in pair and "b" in pair:
+            strength = _tensor_norm(pair["a"]) + _tensor_norm(pair["b"])
+            bucket = (
+                double_strengths
+                if stream == "double_blocks"
+                else single_strengths
+            )
+            bucket[index] = bucket.get(index, 0.0) + strength
+
+    global_module_names: list[str] = []
+    for module, pair in sorted(global_modules.items()):
+        global_module_names.append(module)
+        rank = _pair_rank(f"global.{module}", pair, blockers)
+        if rank is not None:
+            ranks.add(rank)
+        if "a" in pair:
+            _tensor_norm(pair["a"])
+        if "b" in pair:
+            _tensor_norm(pair["b"])
+
+    unmatched_lora_keys = [
+        key for key in unmatched_keys if "lora_" in key.casefold()
+    ]
+    if unmatched_lora_keys:
+        blockers.append(
+            f"Found {len(unmatched_lora_keys)} unrecognised LoRA tensor key(s)"
+        )
+
+    observed_double = sorted(double_strengths)
+    observed_single = sorted(single_strengths)
+    expected_double = list(range(DOUBLE_BLOCK_COUNT))
+    expected_single = list(range(SINGLE_BLOCK_COUNT))
+
+    missing_double = sorted(set(expected_double) - set(observed_double))
+    missing_single = sorted(set(expected_single) - set(observed_single))
+    extra_double = sorted(set(observed_double) - set(expected_double))
+    extra_single = sorted(set(observed_single) - set(expected_single))
+
+    if missing_double:
+        blockers.append(
+            f"Missing Flux 2 double block indices: {missing_double}"
+        )
+    if missing_single:
+        blockers.append(
+            f"Missing Flux 2 single block indices: {missing_single}"
+        )
+    if extra_double:
+        blockers.append(
+            f"Unexpected Flux 2 double block indices: {extra_double}"
+        )
+    if extra_single:
+        blockers.append(
+            f"Unexpected Flux 2 single block indices: {extra_single}"
+        )
+
+    if global_modules:
+        warnings.append(
+            "Global projection LoRA tensors are recorded separately and "
+            "excluded from per-block strengths"
+        )
+    if len(ranks) > 1:
+        blockers.append(
+            "Flux 2 target uses more than one LoRA rank across adapted modules"
+        )
+
+    raw_strengths = [
+        double_strengths.get(index, 0.0)
+        for index in range(DOUBLE_BLOCK_COUNT)
+    ]
+    raw_strengths.extend(
+        single_strengths.get(index, 0.0)
+        for index in range(SINGLE_BLOCK_COUNT)
+    )
+    block_weights = _normalise_strengths(raw_strengths)
+
+    block_tensor_count = sum(len(pair) for pair in block_modules.values())
+    global_tensor_count = sum(len(pair) for pair in global_modules.values())
+
+    return {
+        "tensor_key_count": len(tensors),
+        "model_family": "Flux 2",
+        "lora_type": "Flux 2 (PEFT double+single blocks)",
+        "rank": next(iter(ranks)) if len(ranks) == 1 else None,
+        "rank_values": sorted(ranks),
+        "block_layout": FLUX2_TRANSFORMER_56,
+        "block_count": len(block_weights),
+        "block_weights": block_weights,
+        "raw_block_strengths": raw_strengths,
+        "observed_double_indices": observed_double,
+        "observed_single_indices": observed_single,
+        "missing_double_indices": missing_double,
+        "missing_single_indices": missing_single,
+        "extra_double_indices": extra_double,
+        "extra_single_indices": extra_single,
+        "block_module_count": len(block_modules),
+        "block_tensor_count": block_tensor_count,
+        "global_module_count": len(global_modules),
+        "global_tensor_count": global_tensor_count,
+        "global_modules": global_module_names,
+        "unmatched_tensor_count": len(unmatched_keys),
+        "unmatched_key_sample": unmatched_keys[:25],
+        "warnings": warnings,
+        "blockers": blockers,
+        "ready_for_sealing": not blockers,
+    }
+
+
+def default_tensor_analyser(path: Path) -> Mapping[str, Any]:
+    from safetensors import safe_open
+
+    tensors: dict[str, Any] = {}
+    with safe_open(str(path), framework="pt") as handle:
+        for key in handle.keys():
+            tensors[str(key)] = handle.get_tensor(key)
+    return analyse_flux2_tensor_map(tensors)
+
+
+def _validate_phase89j_report(
+    report: Mapping[str, Any],
+    expected_report_sha256: str,
+) -> dict[str, Any]:
+    if report.get("phase") != "8.9j":
+        raise Flux2LayoutError("Phase 8.9k requires the Phase 8.9j report")
+
+    verified = _verify_embedded_digest(
+        report,
+        "analysis_sha256",
+        "Phase 8.9j report",
+    )
+    expected = str(expected_report_sha256 or "").strip().lower()
+    if verified != expected:
+        raise Flux2LayoutError(
+            f"Unexpected Phase 8.9j report digest: expected {expected}, "
+            f"found {verified}"
+        )
+
+    target = report.get("target")
+    if not isinstance(target, Mapping):
+        raise Flux2LayoutError("Phase 8.9j report has no target object")
+    result = dict(target)
+
+    checks = {
+        "planned_stable_id": EXPECTED_STABLE_ID,
+        "source_sha256": EXPECTED_SOURCE_SHA256,
+        "tensor_key_count": EXPECTED_TENSOR_KEY_COUNT,
+        "rank": EXPECTED_RANK,
+        "rank_values": [EXPECTED_RANK],
+        "observed_double_indices": list(range(DOUBLE_BLOCK_COUNT)),
+        "observed_single_indices": list(range(SINGLE_BLOCK_COUNT)),
+        "block_module_count": EXPECTED_BLOCK_MODULE_COUNT,
+        "block_tensor_count": EXPECTED_BLOCK_TENSOR_COUNT,
+        "global_module_count": EXPECTED_GLOBAL_MODULE_COUNT,
+        "global_tensor_count": EXPECTED_GLOBAL_TENSOR_COUNT,
+        "unmatched_tensor_count": 0,
+        "ready_for_controlled_apply": False,
+    }
+    for field, expected_value in checks.items():
+        if result.get(field) != expected_value:
+            raise Flux2LayoutError(
+                f"Phase 8.9j {field} mismatch: expected {expected_value!r}, "
+                f"found {result.get(field)!r}"
+            )
+
+    global_modules = tuple(result.get("global_module_sample") or [])
+    if global_modules != EXPECTED_GLOBAL_MODULES:
+        raise Flux2LayoutError(
+            "Phase 8.9j global module set no longer matches the observed target"
+        )
+
+    blockers = result.get("blockers") or []
+    blocker_indices: list[int] = []
+    for blocker in blockers:
+        match = _PHASE89J_RANGE_BLOCKER_RE.match(str(blocker))
+        if not match:
+            raise Flux2LayoutError(
+                f"Phase 8.9j contains an unexpected blocker: {blocker}"
+            )
+        blocker_indices.append(int(match.group(1)))
+    if sorted(set(blocker_indices)) != list(range(38, 48)):
+        raise Flux2LayoutError(
+            "Phase 8.9j blockers do not identify single blocks 38..47"
+        )
+
+    return result
+
+
+def _validate_flux2_analysis(analysis: Mapping[str, Any]) -> None:
+    exact_checks = {
+        "tensor_key_count": EXPECTED_TENSOR_KEY_COUNT,
+        "model_family": "Flux 2",
+        "lora_type": "Flux 2 (PEFT double+single blocks)",
+        "rank": EXPECTED_RANK,
+        "rank_values": [EXPECTED_RANK],
+        "block_layout": FLUX2_TRANSFORMER_56,
+        "block_count": TOTAL_BLOCK_COUNT,
+        "observed_double_indices": list(range(DOUBLE_BLOCK_COUNT)),
+        "observed_single_indices": list(range(SINGLE_BLOCK_COUNT)),
+        "missing_double_indices": [],
+        "missing_single_indices": [],
+        "extra_double_indices": [],
+        "extra_single_indices": [],
+        "block_module_count": EXPECTED_BLOCK_MODULE_COUNT,
+        "block_tensor_count": EXPECTED_BLOCK_TENSOR_COUNT,
+        "global_module_count": EXPECTED_GLOBAL_MODULE_COUNT,
+        "global_tensor_count": EXPECTED_GLOBAL_TENSOR_COUNT,
+        "global_modules": list(EXPECTED_GLOBAL_MODULES),
+        "unmatched_tensor_count": 0,
+        "blockers": [],
+        "ready_for_sealing": True,
+    }
+    for field, expected_value in exact_checks.items():
+        if analysis.get(field) != expected_value:
+            raise Flux2LayoutError(
+                f"Flux 2 analysis {field} mismatch: expected {expected_value!r}, "
+                f"found {analysis.get(field)!r}"
+            )
+
+    block_weights = [float(value) for value in analysis.get("block_weights") or []]
+    raw_strengths = [
+        float(value) for value in analysis.get("raw_block_strengths") or []
+    ]
+    if len(block_weights) != TOTAL_BLOCK_COUNT:
+        raise Flux2LayoutError(
+            f"Expected {TOTAL_BLOCK_COUNT} block weights, found {len(block_weights)}"
+        )
+    if len(raw_strengths) != TOTAL_BLOCK_COUNT:
+        raise Flux2LayoutError(
+            f"Expected {TOTAL_BLOCK_COUNT} raw strengths, found {len(raw_strengths)}"
+        )
+    if not all(math.isfinite(value) and 0.0 <= value <= 1.0 for value in block_weights):
+        raise Flux2LayoutError("Flux 2 block weights must be finite values in 0..1")
+    if not all(math.isfinite(value) and value >= 0.0 for value in raw_strengths):
+        raise Flux2LayoutError("Flux 2 raw strengths must be finite and non-negative")
+    if not block_weights or max(block_weights) != 1.0:
+        raise Flux2LayoutError("Flux 2 block weights must contain a strongest block of 1.0")
+    if expected_block_count_for_layout(FLUX2_TRANSFORMER_56) != TOTAL_BLOCK_COUNT:
+        raise Flux2LayoutError("Flux 2 layout registry does not resolve to 56 blocks")
+
+
+def build_flux2_sealed_artifact(
+    phase89j_report: Mapping[str, Any],
+    *,
+    library_root: str | os.PathLike[str],
+    db_path: str | os.PathLike[str],
+    expected_report_sha256: str = EXPECTED_PHASE89J_SHA256,
+    expected_stable_id: str = EXPECTED_STABLE_ID,
+    expected_source_sha256: str = EXPECTED_SOURCE_SHA256,
+    tensor_analyser: TensorAnalyser | None = None,
+) -> dict[str, Any]:
+    phase89j_target = _validate_phase89j_report(
+        phase89j_report,
+        expected_report_sha256,
+    )
+
+    stable_id = str(phase89j_target.get("planned_stable_id") or "").upper()
+    if stable_id != str(expected_stable_id or "").upper():
+        raise Flux2LayoutError(
+            f"Stable ID mismatch: expected {expected_stable_id}, found {stable_id}"
+        )
+
+    relative_path = str(phase89j_target.get("relative_path") or "").strip()
+    db_file_path = str(phase89j_target.get("db_file_path") or "").strip()
+    if not relative_path or not db_file_path:
+        raise Flux2LayoutError("Phase 8.9j target path metadata is incomplete")
+
+    root = Path(library_root).expanduser().resolve(strict=True)
+    source = _safe_source_path(root, relative_path)
+    source_sha256 = _sha256_file(source)
+    expected_source = str(expected_source_sha256 or "").strip().lower()
+    if source_sha256 != expected_source:
+        raise Flux2LayoutError(
+            f"Source SHA-256 mismatch: expected {expected_source}, "
+            f"found {source_sha256}"
+        )
+    if source_sha256 != str(phase89j_target.get("source_sha256") or "").lower():
+        raise Flux2LayoutError(
+            "Source SHA-256 no longer matches the Phase 8.9j report"
+        )
+
+    conn = _open_read_only(db_path)
+    try:
+        integrity = str(conn.execute("PRAGMA integrity_check").fetchone()[0])
+        if integrity.casefold() != "ok":
+            raise Flux2LayoutError(
+                f"Database integrity check failed: {integrity}"
+            )
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE file_path = ?",
+            (db_file_path,),
+        ).fetchone() is not None:
+            raise Flux2LayoutError(
+                f"Target file_path already exists in DB: {db_file_path}"
+            )
+        if conn.execute(
+            "SELECT 1 FROM lora WHERE stable_id = ?",
+            (stable_id,),
+        ).fetchone() is not None:
+            raise Flux2LayoutError(
+                f"Planned stable ID already exists in DB: {stable_id}"
+            )
+    finally:
+        conn.close()
+
+    analyser = tensor_analyser or default_tensor_analyser
+    analysis = dict(analyser(source))
+    _validate_flux2_analysis(analysis)
+
+    target = {
+        "relative_path": relative_path,
+        "db_file_path": db_file_path,
+        "filename": phase89j_target.get("filename") or source.name,
+        "planned_stable_id": stable_id,
+        "base_model_name": "Flux 2",
+        "base_model_code": "FLX",
+        "category_name": phase89j_target.get("category_name"),
+        "category_code": phase89j_target.get("category_code"),
+        "source_size_bytes": source.stat().st_size,
+        "source_mtime": source.stat().st_mtime,
+        "source_sha256": source_sha256,
+        "clip_contributor": phase89j_target.get("clip_contributor"),
+        "clip_tensor_count": phase89j_target.get("clip_tensor_count"),
+        **analysis,
+    }
+
+    artifact: dict[str, Any] = {
+        "phase": "8.9k",
+        "mode": "read-only sealed targeted Flux 2 artifact",
+        "phase89j_analysis_sha256": EXPECTED_PHASE89J_SHA256,
+        "target": target,
+        "summary": {
+            "targets_analysed": 1,
+            "ready_for_later_controlled_apply": 1,
+            "block_rows": TOTAL_BLOCK_COUNT,
+            "global_projection_tensors": EXPECTED_GLOBAL_TENSOR_COUNT,
+            "damaged_flux_targets_untouched": 1,
+        },
+        "safety": {
+            "database_open_mode": (
+                "SQLite URI mode=ro plus PRAGMA query_only=ON"
+            ),
+            "writes_database": False,
+            "creates_backup": False,
+            "runs_full_indexer": False,
+            "discovers_library_files": False,
+            "opens_only_phase89j_target": True,
+            "assigns_stable_ids": False,
+            "deletes_rows": False,
+            "touches_damaged_flux_target": False,
+            "contains_apply_mode": False,
+        },
+    }
+    artifact["artifact_sha256"] = canonical_sha256(artifact)
+    return artifact
+
+
+def print_artifact(artifact: Mapping[str, Any]) -> None:
+    target = artifact["target"]
+    print("=== Phase 8.9k sealed Flux 2 artifact ===")
+    print(f"Mode                       : {artifact['mode']}")
+    print(f"Artifact SHA-256           : {artifact['artifact_sha256']}")
+    print(f"Phase 8.9j SHA-256         : {artifact['phase89j_analysis_sha256']}")
+    print(f"Stable ID                  : {target['planned_stable_id']}")
+    print(f"Source SHA-256             : {target['source_sha256']}")
+    print(f"Tensor keys                : {target['tensor_key_count']}")
+    print(f"Model family               : {target['model_family']}")
+    print(f"LoRA type                  : {target['lora_type']}")
+    print(f"Rank                       : {target['rank']}")
+    print(f"Double blocks              : {target['observed_double_indices']}")
+    print(f"Single blocks              : {target['observed_single_indices']}")
+    print(f"Block modules              : {target['block_module_count']}")
+    print(f"Block tensors              : {target['block_tensor_count']}")
+    print(f"Global modules             : {target['global_module_count']}")
+    print(f"Global tensors             : {target['global_tensor_count']}")
+    print(f"Block layout               : {target['block_layout']}")
+    print(f"Block rows                 : {target['block_count']}")
+    print("Ready for later apply      : True")
+    for warning in target["warnings"]:
+        print(f"Warning                    : {warning}")
+    print("No database changes were made.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Seal the Phase 8.9j target as the distinct Flux 2 "
+            "8-double plus 48-single architecture"
+        )
+    )
+    parser.add_argument("--analysis", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument(
+        "--expected-analysis-sha256",
+        default=EXPECTED_PHASE89J_SHA256,
+    )
+    parser.add_argument("--expected-stable-id", default=EXPECTED_STABLE_ID)
+    parser.add_argument(
+        "--expected-source-sha256",
+        default=EXPECTED_SOURCE_SHA256,
+    )
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    artifact = build_flux2_sealed_artifact(
+        load_json_object(args.analysis, "Phase 8.9j analysis"),
+        library_root=args.root,
+        db_path=args.db,
+        expected_report_sha256=args.expected_analysis_sha256,
+        expected_stable_id=args.expected_stable_id,
+        expected_source_sha256=args.expected_source_sha256,
+    )
+    verify_artifact_digest(artifact)
+    print_artifact(artifact)
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        print(f"JSON artifact written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/tests/test_phase89k_flux2_layout_support.py
+++ b/Database/backend/tests/test_phase89k_flux2_layout_support.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from block_layouts import (
+    FLUX2_TRANSFORMER_56,
+    expected_block_count_for_layout,
+    infer_layout_from_block_count,
+    make_flux_layout,
+    normalize_block_layout,
+)
+from phase89k_flux2_layout_support import (
+    EXPECTED_GLOBAL_MODULES,
+    EXPECTED_STABLE_ID,
+    Flux2LayoutError,
+    analyse_flux2_tensor_map,
+    build_flux2_sealed_artifact,
+    canonical_sha256,
+    verify_artifact_digest,
+)
+
+
+RELATIVE_PATH = "FLUX/02 - Styles/aidmaMJ61Flux.2v0.5.safetensors"
+DB_FILE_PATH = f"/loras/{RELATIVE_PATH}"
+
+
+class _Scalar:
+    def __init__(self, value: float) -> None:
+        self._value = float(value)
+
+    def item(self) -> float:
+        return self._value
+
+
+class _Tensor:
+    def __init__(self, shape: tuple[int, int], norm: float) -> None:
+        self.shape = shape
+        self.ndim = len(shape)
+        self._norm = float(norm)
+
+    def norm(self) -> _Scalar:
+        return _Scalar(self._norm)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _source(root: Path, payload: bytes = b"phase89k-flux2-target") -> Path:
+    path = root / Path(*RELATIVE_PATH.split("/"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    return path
+
+
+def _db(path: Path, *, collision: bool = False) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            stable_id TEXT
+        )
+        """
+    )
+    if collision:
+        conn.execute(
+            "INSERT INTO lora (file_path, stable_id) VALUES (?, ?)",
+            ("/loras/existing.safetensors", EXPECTED_STABLE_ID),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _pair(prefix: str, seed: float) -> dict[str, _Tensor]:
+    return {
+        f"{prefix}.lora_A.weight": _Tensor((16, 4), seed),
+        f"{prefix}.lora_B.weight": _Tensor((6, 16), seed + 0.5),
+    }
+
+
+def _valid_tensors() -> dict[str, _Tensor]:
+    tensors: dict[str, _Tensor] = {}
+    seed = 1.0
+
+    for index in range(8):
+        modules = ["img_attn.proj", "txt_attn.qkv", "img_mlp.2"]
+        for module in modules:
+            tensors.update(
+                _pair(
+                    f"base_model.model.double_blocks.{index}.{module}",
+                    seed,
+                )
+            )
+            seed += 1.0
+
+    for index in range(48):
+        modules = ["linear1", "linear2"]
+        if index < 8:
+            modules.append("modulation.lin")
+        for module in modules:
+            tensors.update(
+                _pair(
+                    f"base_model.model.single_blocks.{index}.{module}",
+                    seed,
+                )
+            )
+            seed += 1.0
+
+    for module in EXPECTED_GLOBAL_MODULES:
+        tensors.update(_pair(f"base_model.model.{module}", seed))
+        seed += 1.0
+
+    return tensors
+
+
+def _phase89j_report(source_sha: str) -> dict[str, object]:
+    blockers = []
+    for index in range(38, 48):
+        blocker = (
+            f"Out-of-range single_blocks index {index}; "
+            "supported range is 0..37"
+        )
+        blockers.extend([blocker, blocker])
+
+    report: dict[str, object] = {
+        "phase": "8.9j",
+        "mode": "read-only targeted PEFT Flux analysis",
+        "diagnostics_sha256": "diagnostics-digest",
+        "target": {
+            "relative_path": RELATIVE_PATH,
+            "db_file_path": DB_FILE_PATH,
+            "filename": Path(RELATIVE_PATH).name,
+            "planned_stable_id": EXPECTED_STABLE_ID,
+            "base_model_name": "Flux",
+            "base_model_code": "FLX",
+            "category_name": "Styles",
+            "category_code": "STL",
+            "source_sha256": source_sha,
+            "clip_contributor": False,
+            "clip_tensor_count": 0,
+            "tensor_key_count": 276,
+            "rank": 16,
+            "rank_values": [16],
+            "observed_double_indices": list(range(8)),
+            "observed_single_indices": list(range(48)),
+            "block_module_count": 128,
+            "block_tensor_count": 256,
+            "global_module_count": 10,
+            "global_tensor_count": 20,
+            "global_module_sample": list(EXPECTED_GLOBAL_MODULES),
+            "unmatched_tensor_count": 0,
+            "ready_for_controlled_apply": False,
+            "blockers": blockers,
+        },
+        "summary": {
+            "targets_analysed": 1,
+            "ready_for_controlled_apply": 0,
+            "blocked_targets": 1,
+        },
+        "safety": {"writes_database": False},
+    }
+    report["analysis_sha256"] = canonical_sha256(report)
+    return report
+
+
+def test_layout_registry_supports_flux2_56() -> None:
+    assert normalize_block_layout("FLUX2_TRANSFORMER_56") == FLUX2_TRANSFORMER_56
+    assert expected_block_count_for_layout(FLUX2_TRANSFORMER_56) == 56
+    assert infer_layout_from_block_count(56) == FLUX2_TRANSFORMER_56
+    assert (
+        make_flux_layout("Flux 2 (PEFT double+single blocks)", 56)
+        == FLUX2_TRANSFORMER_56
+    )
+
+
+def test_valid_flux2_tensor_map_is_exactly_8_plus_48() -> None:
+    result = analyse_flux2_tensor_map(_valid_tensors())
+
+    assert result["tensor_key_count"] == 276
+    assert result["model_family"] == "Flux 2"
+    assert result["rank"] == 16
+    assert result["rank_values"] == [16]
+    assert result["block_layout"] == FLUX2_TRANSFORMER_56
+    assert result["block_count"] == 56
+    assert len(result["block_weights"]) == 56
+    assert len(result["raw_block_strengths"]) == 56
+    assert result["observed_double_indices"] == list(range(8))
+    assert result["observed_single_indices"] == list(range(48))
+    assert result["block_module_count"] == 128
+    assert result["block_tensor_count"] == 256
+    assert result["global_modules"] == list(EXPECTED_GLOBAL_MODULES)
+    assert result["global_tensor_count"] == 20
+    assert result["unmatched_tensor_count"] == 0
+    assert result["blockers"] == []
+    assert result["ready_for_sealing"] is True
+    assert max(result["block_weights"]) == 1.0
+
+
+def test_incomplete_pair_blocks_flux2_sealing() -> None:
+    tensors = _valid_tensors()
+    tensors.pop(
+        "base_model.model.single_blocks.47.linear2.lora_B.weight"
+    )
+
+    result = analyse_flux2_tensor_map(tensors)
+
+    assert result["ready_for_sealing"] is False
+    assert any("Incomplete LoRA pair" in item for item in result["blockers"])
+
+
+def test_missing_architecture_block_is_rejected() -> None:
+    tensors = _valid_tensors()
+    for key in list(tensors):
+        if key.startswith("base_model.model.double_blocks.7."):
+            tensors.pop(key)
+
+    result = analyse_flux2_tensor_map(tensors)
+
+    assert result["ready_for_sealing"] is False
+    assert result["missing_double_indices"] == [7]
+    assert any("Missing Flux 2 double block indices" in item for item in result["blockers"])
+
+
+def test_builds_sealed_artifact_without_changing_db(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    report = _phase89j_report(_sha256(source))
+    before = db.read_bytes()
+
+    artifact = build_flux2_sealed_artifact(
+        report,
+        library_root=root,
+        db_path=db,
+        expected_report_sha256=str(report["analysis_sha256"]),
+        expected_source_sha256=_sha256(source),
+        tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
+    )
+
+    target = artifact["target"]
+    assert artifact["phase"] == "8.9k"
+    assert target["planned_stable_id"] == EXPECTED_STABLE_ID
+    assert target["model_family"] == "Flux 2"
+    assert target["block_layout"] == FLUX2_TRANSFORMER_56
+    assert target["block_count"] == 56
+    assert len(target["block_weights"]) == 56
+    assert len(target["raw_block_strengths"]) == 56
+    assert artifact["safety"]["writes_database"] is False
+    assert artifact["safety"]["contains_apply_mode"] is False
+    assert verify_artifact_digest(artifact) == artifact["artifact_sha256"]
+    assert db.read_bytes() == before
+
+
+def test_unexpected_phase89j_blocker_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db")
+    report = _phase89j_report(_sha256(source))
+    target = dict(report["target"])
+    target["blockers"] = ["Unexpected tensor namespace"]
+    report["target"] = target
+    report.pop("analysis_sha256")
+    report["analysis_sha256"] = canonical_sha256(report)
+
+    with pytest.raises(Flux2LayoutError, match="unexpected blocker"):
+        build_flux2_sealed_artifact(
+            report,
+            library_root=root,
+            db_path=db,
+            expected_report_sha256=str(report["analysis_sha256"]),
+            expected_source_sha256=_sha256(source),
+            tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
+        )
+
+
+def test_existing_stable_id_collision_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "loras"
+    source = _source(root)
+    db = _db(tmp_path / "lora.db", collision=True)
+    report = _phase89j_report(_sha256(source))
+
+    with pytest.raises(Flux2LayoutError, match="Planned stable ID already exists"):
+        build_flux2_sealed_artifact(
+            report,
+            library_root=root,
+            db_path=db,
+            expected_report_sha256=str(report["analysis_sha256"]),
+            expected_source_sha256=_sha256(source),
+            tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
+        )

--- a/Database/backend/tests/test_phase89k_flux2_layout_support.py
+++ b/Database/backend/tests/test_phase89k_flux2_layout_support.py
@@ -11,6 +11,7 @@ BACKEND = Path(__file__).resolve().parents[1]
 if str(BACKEND) not in sys.path:
     sys.path.insert(0, str(BACKEND))
 
+import phase89k_flux2_layout_support as phase89k
 from block_layouts import (
     FLUX2_TRANSFORMER_56,
     expected_block_count_for_layout,
@@ -20,6 +21,7 @@ from block_layouts import (
 )
 from phase89k_flux2_layout_support import (
     EXPECTED_GLOBAL_MODULES,
+    EXPECTED_SOURCE_SHA256,
     EXPECTED_STABLE_ID,
     Flux2LayoutError,
     analyse_flux2_tensor_map,
@@ -175,6 +177,14 @@ def _phase89j_report(source_sha: str) -> dict[str, object]:
     return report
 
 
+def _mock_live_source_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        phase89k,
+        "_sha256_file",
+        lambda _: EXPECTED_SOURCE_SHA256,
+    )
+
+
 def test_layout_registry_supports_flux2_56() -> None:
     assert normalize_block_layout("FLUX2_TRANSFORMER_56") == FLUX2_TRANSFORMER_56
     assert expected_block_count_for_layout(FLUX2_TRANSFORMER_56) == 56
@@ -233,19 +243,23 @@ def test_missing_architecture_block_is_rejected() -> None:
     assert any("Missing Flux 2 double block indices" in item for item in result["blockers"])
 
 
-def test_builds_sealed_artifact_without_changing_db(tmp_path: Path) -> None:
+def test_builds_sealed_artifact_without_changing_db(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     root = tmp_path / "loras"
-    source = _source(root)
+    _source(root)
     db = _db(tmp_path / "lora.db")
-    report = _phase89j_report(_sha256(source))
+    report = _phase89j_report(EXPECTED_SOURCE_SHA256)
     before = db.read_bytes()
+    _mock_live_source_hash(monkeypatch)
 
     artifact = build_flux2_sealed_artifact(
         report,
         library_root=root,
         db_path=db,
         expected_report_sha256=str(report["analysis_sha256"]),
-        expected_source_sha256=_sha256(source),
+        expected_source_sha256=EXPECTED_SOURCE_SHA256,
         tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
     )
 
@@ -263,16 +277,20 @@ def test_builds_sealed_artifact_without_changing_db(tmp_path: Path) -> None:
     assert db.read_bytes() == before
 
 
-def test_unexpected_phase89j_blocker_is_rejected(tmp_path: Path) -> None:
+def test_unexpected_phase89j_blocker_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     root = tmp_path / "loras"
-    source = _source(root)
+    _source(root)
     db = _db(tmp_path / "lora.db")
-    report = _phase89j_report(_sha256(source))
+    report = _phase89j_report(EXPECTED_SOURCE_SHA256)
     target = dict(report["target"])
     target["blockers"] = ["Unexpected tensor namespace"]
     report["target"] = target
     report.pop("analysis_sha256")
     report["analysis_sha256"] = canonical_sha256(report)
+    _mock_live_source_hash(monkeypatch)
 
     with pytest.raises(Flux2LayoutError, match="unexpected blocker"):
         build_flux2_sealed_artifact(
@@ -280,16 +298,20 @@ def test_unexpected_phase89j_blocker_is_rejected(tmp_path: Path) -> None:
             library_root=root,
             db_path=db,
             expected_report_sha256=str(report["analysis_sha256"]),
-            expected_source_sha256=_sha256(source),
+            expected_source_sha256=EXPECTED_SOURCE_SHA256,
             tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
         )
 
 
-def test_existing_stable_id_collision_is_rejected(tmp_path: Path) -> None:
+def test_existing_stable_id_collision_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     root = tmp_path / "loras"
-    source = _source(root)
+    _source(root)
     db = _db(tmp_path / "lora.db", collision=True)
-    report = _phase89j_report(_sha256(source))
+    report = _phase89j_report(EXPECTED_SOURCE_SHA256)
+    _mock_live_source_hash(monkeypatch)
 
     with pytest.raises(Flux2LayoutError, match="Planned stable ID already exists"):
         build_flux2_sealed_artifact(
@@ -297,6 +319,6 @@ def test_existing_stable_id_collision_is_rejected(tmp_path: Path) -> None:
             library_root=root,
             db_path=db,
             expected_report_sha256=str(report["analysis_sha256"]),
-            expected_source_sha256=_sha256(source),
+            expected_source_sha256=EXPECTED_SOURCE_SHA256,
             tensor_analyser=lambda _: analyse_flux2_tensor_map(_valid_tensors()),
         )

--- a/docs/phase89k-flux2-layout-support.md
+++ b/docs/phase89k-flux2-layout-support.md
@@ -1,0 +1,105 @@
+# Phase 8.9k Flux 2 layout support
+
+Phase 8.9k adds a distinct read-only layout for the PEFT-style target `FLX-STL-263` after the Phase 8.9j live analysis proved that it is not a standard Flux 1 architecture.
+
+## Live evidence carried forward
+
+Phase 8.9j established the following immutable inputs:
+
+- stable ID: `FLX-STL-263`
+- source: `FLUX/02 - Styles/aidmaMJ61Flux.2v0.5.safetensors`
+- source SHA-256: `c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7`
+- Phase 8.9j analysis SHA-256: `7c886a07e87fa36081645d34bd578001420e65a380c6543b17c9b9ee1fb8dc48`
+- tensor keys: 276
+- LoRA rank: 16
+- double blocks: `0..7`
+- single blocks: `0..47`
+- adapted block modules: 128
+- block tensors: 256
+- global projection modules: 10
+- global projection tensors: 20
+- unmatched tensors: 0
+
+The Phase 8.9j report remains blocked only because the earlier analyser intentionally tested the source against the Flux 1 ranges of 19 double blocks and 38 single blocks.
+
+## New layout
+
+Phase 8.9k registers:
+
+```text
+flux2_transformer_56
+```
+
+The ordered layout is:
+
+```text
+DOUBLE_0 .. DOUBLE_7
+SINGLE_0 .. SINGLE_47
+```
+
+This is 56 logical block rows. It is separate from the existing `flux_unet_57` layout and does not alter existing Flux 1 block mathematics.
+
+## Sealing behaviour
+
+`phase89k_flux2_layout_support.py`:
+
+1. loads the exact Phase 8.9j JSON report
+2. verifies its canonical analysis digest
+3. requires the Phase 8.9j observations to match the live 8-double and 48-single architecture
+4. requires the only Phase 8.9j blockers to be the old single-block range checks for indices `38..47`
+5. verifies the source SHA-256 is unchanged
+6. opens SQLite with URI `mode=ro` and `PRAGMA query_only = ON`
+7. confirms the file path and stable ID remain absent
+8. reopens only the approved source file
+9. validates every LoRA A/B pair, tensor shape and rank
+10. requires all 8 double blocks and all 48 single blocks
+11. requires the exact 128 block modules, 256 block tensors, 10 global modules and 20 global tensors
+12. computes and seals all 56 block weights and raw strengths
+13. emits a canonical artifact SHA-256
+
+## Safety boundary
+
+Phase 8.9k:
+
+- writes no database rows
+- creates no backup
+- has no apply mode
+- does not run the full indexer
+- does not enumerate the library
+- does not change `delta_inspector_engine.py`
+- does not touch `FLX-BDY-071`
+- does not modify existing `flux_unet_57` results
+
+A later database write requires a separate guarded phase and fresh explicit approval.
+
+## Bender validation
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89k_flux2_layout_support.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89k_flux2_layout_support.py `
+  Database\backend\block_layouts.py
+```
+
+Expected: 7 tests passed and silent compilation.
+
+## Planned Nibbler run
+
+After review and merge, run inside a temporary backend container:
+
+```bash
+sudo docker compose --env-file .env run --rm --no-deps -T backend \
+  python phase89k_flux2_layout_support.py \
+  --analysis /data/phase89j_flx_stl_263_analysis.json \
+  --root /loras \
+  --db /data/lora_master.db \
+  --expected-analysis-sha256 7c886a07e87fa36081645d34bd578001420e65a380c6543b17c9b9ee1fb8dc48 \
+  --expected-stable-id FLX-STL-263 \
+  --expected-source-sha256 c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7 \
+  --json /data/phase89k_flx_stl_263_flux2_artifact.json
+```
+
+The database SHA-256 and backup count must remain unchanged.

--- a/docs/phase89k-flux2-layout-support.md
+++ b/docs/phase89k-flux2-layout-support.md
@@ -86,6 +86,8 @@ A later database write requires a separate guarded phase and fresh explicit appr
 
 Expected: 7 tests passed and silent compilation.
 
+The first Bender run exposed a test-fixture mismatch: synthetic temporary files naturally do not have the immutable live source SHA-256 required by the Phase 8.9j report guard. Follow-up commit `d9efe884` changed only the tests so they mock the source hash reader while leaving the production guard locked to the real source digest.
+
 ## Planned Nibbler run
 
 After review and merge, run inside a temporary backend container:


### PR DESCRIPTION
## What changed

- Added the distinct `flux2_transformer_56` layout to the block-layout registry.
- Added a read-only Phase 8.9k analyser and sealing path for `FLX-STL-263`.
- Consumes and verifies the exact Phase 8.9j analysis digest `7c886a07e87fa36081645d34bd578001420e65a380c6543b17c9b9ee1fb8dc48`.
- Requires the live source SHA-256 `c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7`.
- Requires the observed Flux 2 architecture exactly: 8 double blocks, 48 single blocks, 128 block modules, 256 block tensors, 10 global modules, 20 global tensors, 276 total keys and rank 16.
- Computes and seals all 56 ordered block weights as `DOUBLE_0..7 + SINGLE_0..47`.
- Records global projection modules separately and excludes them from per-block strengths.
- Emits a canonical artifact SHA-256 for any later guarded apply phase.
- Leaves the existing `flux_unet_57` path unchanged.
- Leaves the damaged `FLX-BDY-071` source untouched.

## Safety boundary

- SQLite URI `mode=ro` plus `PRAGMA query_only = ON`.
- No inserts, updates, deletes, backups or stable-ID assignments.
- No apply mode.
- No full indexer invocation or library enumeration.
- Opens only the Phase 8.9j-approved source.
- Does not modify `delta_inspector_engine.py`.

## Validation

Verified on Bender from the repository root:

```text
7 passed in 0.10s
python -m py_compile: passed silently
```

The first Bender run exposed a synthetic-fixture source-hash mismatch. Follow-up commits changed only the tests so their temporary file mocks the real live source digest. Production validation remains hard-locked to the exact Phase 8.9j source SHA-256.