### PR TITLE
Phase 8.9m: add post-apply verification and closeout

### DIFF
--- a/Database/backend/phase89m_post_apply_closeout.py
+++ b/Database/backend/phase89m_post_apply_closeout.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import quote
+
+from phase89g_targeted_flux_analysis import _safe_source_path, _sha256_file
+from phase89k_flux2_layout_support import (
+    EXPECTED_GLOBAL_MODULES,
+    canonical_sha256,
+    load_json_object,
+    verify_artifact_digest,
+)
+
+
+class Phase89mVerificationError(RuntimeError):
+    pass
+
+
+EXPECTED_ARTIFACT_SHA256 = (
+    "adad9f9c3eb65bf0b2c0774e3c0c1508c43603ed3774c804f5ef49123d6a48df"
+)
+EXPECTED_CURRENT_DB_SHA256 = (
+    "6526505261ed62c79c433217161716e6d0bb9b286fb266867f9e6c87b1fa2357"
+)
+EXPECTED_BACKUP_DB_SHA256 = (
+    "d732b2739cd2df278b104e325d17481413152d89776d8f1abdc59637bc86c79e"
+)
+EXPECTED_BACKUP_NAME = (
+    "lora_master.phase89l.20260729T221823Z.adad9f9c3eb6.db"
+)
+EXPECTED_SOURCE_SHA256 = (
+    "c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7"
+)
+EXPECTED_STABLE_ID = "FLX-STL-263"
+DAMAGED_STABLE_ID = "FLX-BDY-071"
+EXPECTED_LAYOUT = "flux2_transformer_56"
+EXPECTED_TARGET_LORA_ID = 2834
+EXPECTED_CURRENT_LORA_ROWS = 2834
+EXPECTED_BACKUP_LORA_ROWS = 2833
+EXPECTED_CURRENT_BLOCK_ROWS = 4348
+EXPECTED_BACKUP_BLOCK_ROWS = 4292
+EXPECTED_BLOCK_COUNT = 56
+EXPECTED_TENSOR_KEY_COUNT = 276
+EXPECTED_RANK = 16
+EXPECTED_BLOCK_MODULE_COUNT = 128
+EXPECTED_BLOCK_TENSOR_COUNT = 256
+EXPECTED_GLOBAL_MODULE_COUNT = 10
+EXPECTED_GLOBAL_TENSOR_COUNT = 20
+
+
+def _file_sha256(path: str | os.PathLike[str]) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _open_read_only(path: str | os.PathLike[str]) -> sqlite3.Connection:
+    resolved = Path(path).expanduser().resolve(strict=True)
+    uri_path = quote(resolved.as_posix(), safe="/:")
+    conn = sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def _require_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise Phase89mVerificationError(
+            f"{label} mismatch: expected {expected!r}, found {actual!r}"
+        )
+
+
+def _integrity_check(conn: sqlite3.Connection, label: str) -> str:
+    row = conn.execute("PRAGMA integrity_check").fetchone()
+    result = str(row[0] if row else "")
+    if result.casefold() != "ok":
+        raise Phase89mVerificationError(
+            f"{label} integrity_check failed: {result or 'no result'}"
+        )
+    return result
+
+
+def _validate_numeric_vector(
+    values: Any,
+    *,
+    label: str,
+    count: int,
+    unit_range: bool,
+) -> list[float]:
+    if not isinstance(values, list):
+        raise Phase89mVerificationError(f"{label} must be a JSON list")
+    if len(values) != count:
+        raise Phase89mVerificationError(
+            f"{label} count mismatch: expected {count}, found {len(values)}"
+        )
+
+    result: list[float] = []
+    for index, raw in enumerate(values):
+        value = float(raw)
+        if not math.isfinite(value):
+            raise Phase89mVerificationError(
+                f"{label}[{index}] is not finite: {raw!r}"
+            )
+        if unit_range and not 0.0 <= value <= 1.0:
+            raise Phase89mVerificationError(
+                f"{label}[{index}] is outside [0, 1]: {value}"
+            )
+        if not unit_range and value < 0.0:
+            raise Phase89mVerificationError(
+                f"{label}[{index}] is negative: {value}"
+            )
+        result.append(value)
+    return result
+
+
+def _validate_artifact(
+    artifact: Mapping[str, Any],
+    *,
+    expected_artifact_sha256: str,
+    expected_source_sha256: str,
+) -> tuple[str, dict[str, Any]]:
+    _require_equal(artifact.get("phase"), "8.9k", "artifact phase")
+    _require_equal(
+        artifact.get("mode"),
+        "read-only sealed targeted Flux 2 artifact",
+        "artifact mode",
+    )
+
+    digest = verify_artifact_digest(artifact)
+    _require_equal(digest, expected_artifact_sha256, "artifact SHA-256")
+
+    summary = artifact.get("summary") or {}
+    _require_equal(summary.get("targets_analysed"), 1, "targets_analysed")
+    _require_equal(
+        summary.get("ready_for_later_controlled_apply"),
+        1,
+        "ready_for_later_controlled_apply",
+    )
+    _require_equal(summary.get("block_rows"), EXPECTED_BLOCK_COUNT, "block_rows")
+    _require_equal(
+        summary.get("global_projection_tensors"),
+        EXPECTED_GLOBAL_TENSOR_COUNT,
+        "global_projection_tensors",
+    )
+    _require_equal(
+        summary.get("damaged_flux_targets_untouched"),
+        1,
+        "damaged_flux_targets_untouched",
+    )
+
+    safety = artifact.get("safety") or {}
+    for field in (
+        "writes_database",
+        "creates_backup",
+        "contains_apply_mode",
+        "runs_full_indexer",
+        "discovers_library_files",
+        "assigns_stable_ids",
+        "deletes_rows",
+        "touches_damaged_flux_target",
+    ):
+        _require_equal(safety.get(field), False, f"artifact safety {field}")
+
+    target = dict(artifact.get("target") or {})
+    exact_checks = {
+        "planned_stable_id": EXPECTED_STABLE_ID,
+        "base_model_name": "Flux 2",
+        "base_model_code": "FLX",
+        "category_name": "Styles",
+        "category_code": "STL",
+        "source_sha256": expected_source_sha256,
+        "tensor_key_count": EXPECTED_TENSOR_KEY_COUNT,
+        "model_family": "Flux 2",
+        "lora_type": "Flux 2 (PEFT double+single blocks)",
+        "rank": EXPECTED_RANK,
+        "rank_values": [EXPECTED_RANK],
+        "block_layout": EXPECTED_LAYOUT,
+        "block_count": EXPECTED_BLOCK_COUNT,
+        "observed_double_indices": list(range(8)),
+        "observed_single_indices": list(range(48)),
+        "missing_double_indices": [],
+        "missing_single_indices": [],
+        "extra_double_indices": [],
+        "extra_single_indices": [],
+        "block_module_count": EXPECTED_BLOCK_MODULE_COUNT,
+        "block_tensor_count": EXPECTED_BLOCK_TENSOR_COUNT,
+        "global_module_count": EXPECTED_GLOBAL_MODULE_COUNT,
+        "global_tensor_count": EXPECTED_GLOBAL_TENSOR_COUNT,
+        "global_modules": list(EXPECTED_GLOBAL_MODULES),
+        "unmatched_tensor_count": 0,
+        "blockers": [],
+        "ready_for_sealing": True,
+    }
+    for field, expected in exact_checks.items():
+        actual = target.get(field)
+        if field == "planned_stable_id":
+            actual = str(actual or "").strip().upper()
+        if field == "source_sha256":
+            actual = str(actual or "").strip().lower()
+        _require_equal(actual, expected, f"artifact target {field}")
+
+    for field in (
+        "relative_path",
+        "db_file_path",
+        "filename",
+        "source_size_bytes",
+        "source_mtime",
+    ):
+        if target.get(field) in (None, ""):
+            raise Phase89mVerificationError(
+                f"artifact target is missing required field {field}"
+            )
+
+    target["block_weights"] = _validate_numeric_vector(
+        target.get("block_weights"),
+        label="block_weights",
+        count=EXPECTED_BLOCK_COUNT,
+        unit_range=True,
+    )
+    target["raw_block_strengths"] = _validate_numeric_vector(
+        target.get("raw_block_strengths"),
+        label="raw_block_strengths",
+        count=EXPECTED_BLOCK_COUNT,
+        unit_range=False,
+    )
+    if max(target["block_weights"], default=0.0) != 1.0:
+        raise Phase89mVerificationError(
+            "block_weights must contain a strongest value of exactly 1.0"
+        )
+    if any(value <= 0.0 for value in target["block_weights"]):
+        raise Phase89mVerificationError(
+            "all 56 Flux 2 block weights must be greater than zero"
+        )
+    return digest, target
+
+
+def _verify_source(
+    library_root: str | os.PathLike[str],
+    target: Mapping[str, Any],
+    *,
+    expected_source_sha256: str,
+) -> Path:
+    root = Path(library_root).expanduser().resolve(strict=True)
+    if not root.is_dir():
+        raise Phase89mVerificationError(
+            f"LoRA library root is not a directory: {root}"
+        )
+    source = _safe_source_path(root, str(target["relative_path"]))
+    _require_equal(_sha256_file(source), expected_source_sha256, "source SHA-256")
+    _require_equal(
+        source.stat().st_size,
+        int(target["source_size_bytes"]),
+        "source size",
+    )
+    expected_mtime = float(target["source_mtime"])
+    if abs(source.stat().st_mtime - expected_mtime) > 1e-6:
+        raise Phase89mVerificationError(
+            "source mtime mismatch: "
+            f"expected {expected_mtime!r}, found {source.stat().st_mtime!r}"
+        )
+    return source
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    columns = [str(row[1]) for row in rows]
+    if not columns:
+        raise Phase89mVerificationError(f"missing table or columns: {table}")
+    return columns
+
+
+def _verify_backup_rows_preserved(
+    backup: sqlite3.Connection,
+    current: sqlite3.Connection,
+    table: str,
+) -> int:
+    backup_columns = _table_columns(backup, table)
+    current_columns = _table_columns(current, table)
+    _require_equal(current_columns, backup_columns, f"{table} column list")
+
+    backup_rows = backup.execute(f"SELECT * FROM {table} ORDER BY id").fetchall()
+    current_rows = current.execute(f"SELECT * FROM {table} ORDER BY id").fetchall()
+    current_by_id = {int(row["id"]): row for row in current_rows}
+
+    for before in backup_rows:
+        row_id = int(before["id"])
+        after = current_by_id.get(row_id)
+        if after is None:
+            raise Phase89mVerificationError(
+                f"pre-existing {table} row was deleted: id={row_id}"
+            )
+        for column in backup_columns:
+            if after[column] != before[column]:
+                raise Phase89mVerificationError(
+                    f"pre-existing {table} row changed: "
+                    f"id={row_id}, column={column}, "
+                    f"before={before[column]!r}, after={after[column]!r}"
+                )
+    return len(backup_rows)
+
+
+def _duplicate_stable_ids(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    return [
+        dict(row)
+        for row in conn.execute(
+            """
+            SELECT stable_id, COUNT(*) AS count
+            FROM lora
+            WHERE stable_id IS NOT NULL
+              AND TRIM(stable_id) <> ''
+            GROUP BY stable_id
+            HAVING COUNT(*) > 1
+            ORDER BY stable_id
+            """
+        )
+    ]
+
+
+def _verify_target_row(
+    current: sqlite3.Connection,
+    backup: sqlite3.Connection,
+    target: Mapping[str, Any],
+    *,
+    expected_target_lora_id: int,
+) -> tuple[int, int]:
+    backup_count = int(
+        backup.execute(
+            "SELECT COUNT(*) FROM lora WHERE stable_id = ? OR file_path = ?",
+            (EXPECTED_STABLE_ID, target["db_file_path"]),
+        ).fetchone()[0]
+    )
+    _require_equal(backup_count, 0, "backup target row count")
+
+    rows = current.execute(
+        "SELECT * FROM lora WHERE stable_id = ? OR file_path = ?",
+        (EXPECTED_STABLE_ID, target["db_file_path"]),
+    ).fetchall()
+    _require_equal(len(rows), 1, "current target row count")
+    row = rows[0]
+    lora_id = int(row["id"])
+    _require_equal(lora_id, expected_target_lora_id, "target lora id")
+
+    exact_fields = {
+        "file_path": target["db_file_path"],
+        "filename": target["filename"],
+        "base_model_name": "Flux 2",
+        "base_model_code": "FLX",
+        "category_name": "Styles",
+        "category_code": "STL",
+        "model_family": "Flux 2",
+        "lora_type": "Flux 2 (PEFT double+single blocks)",
+        "rank": EXPECTED_RANK,
+        "has_block_weights": 1,
+        "block_layout": EXPECTED_LAYOUT,
+        "clip_contributor": 0,
+        "clip_tensor_count": 0,
+        "stable_id": EXPECTED_STABLE_ID,
+    }
+    for field, expected in exact_fields.items():
+        _require_equal(row[field], expected, f"target lora {field}")
+
+    _require_equal(
+        float(row["last_modified"]),
+        float(target["source_mtime"]),
+        "target lora last_modified",
+    )
+    if not str(row["created_at"] or "").strip():
+        raise Phase89mVerificationError("target lora created_at is empty")
+    _require_equal(row["updated_at"], row["created_at"], "target timestamps")
+
+    blocks = current.execute(
+        """
+        SELECT *
+        FROM lora_block_weights
+        WHERE lora_id = ?
+        ORDER BY block_index
+        """,
+        (lora_id,),
+    ).fetchall()
+    _require_equal(len(blocks), EXPECTED_BLOCK_COUNT, "target block row count")
+
+    for index, block in enumerate(blocks):
+        _require_equal(block["stable_id"], EXPECTED_STABLE_ID, f"block {index} stable_id")
+        _require_equal(int(block["block_index"]), index, f"block {index} index")
+        if not math.isclose(
+            float(block["weight"]),
+            float(target["block_weights"][index]),
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        ):
+            raise Phase89mVerificationError(
+                f"block {index} weight mismatch"
+            )
+        if not math.isclose(
+            float(block["raw_strength"]),
+            float(target["raw_block_strengths"][index]),
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise Phase89mVerificationError(
+                f"block {index} raw_strength mismatch"
+            )
+    return lora_id, len(blocks)
+
+
+def verify_phase89m_closeout(
+    *,
+    artifact_path: str | os.PathLike[str],
+    current_db_path: str | os.PathLike[str],
+    backup_db_path: str | os.PathLike[str],
+    library_root: str | os.PathLike[str],
+    expected_artifact_sha256: str = EXPECTED_ARTIFACT_SHA256,
+    expected_current_db_sha256: str = EXPECTED_CURRENT_DB_SHA256,
+    expected_backup_db_sha256: str = EXPECTED_BACKUP_DB_SHA256,
+    expected_backup_name: str = EXPECTED_BACKUP_NAME,
+    expected_source_sha256: str = EXPECTED_SOURCE_SHA256,
+    expected_target_lora_id: int = EXPECTED_TARGET_LORA_ID,
+    expected_current_lora_rows: int = EXPECTED_CURRENT_LORA_ROWS,
+    expected_backup_lora_rows: int = EXPECTED_BACKUP_LORA_ROWS,
+    expected_current_block_rows: int = EXPECTED_CURRENT_BLOCK_ROWS,
+    expected_backup_block_rows: int = EXPECTED_BACKUP_BLOCK_ROWS,
+) -> dict[str, Any]:
+    artifact_file = Path(artifact_path).expanduser().resolve(strict=True)
+    current_file = Path(current_db_path).expanduser().resolve(strict=True)
+    backup_file = Path(backup_db_path).expanduser().resolve(strict=True)
+
+    _require_equal(backup_file.name, expected_backup_name, "backup filename")
+
+    current_sha256 = _file_sha256(current_file)
+    backup_sha256 = _file_sha256(backup_file)
+    _require_equal(current_sha256, expected_current_db_sha256, "current DB SHA-256")
+    _require_equal(backup_sha256, expected_backup_db_sha256, "backup DB SHA-256")
+
+    artifact = load_json_object(artifact_file, "Phase 8.9k artifact")
+    artifact_sha256, target = _validate_artifact(
+        artifact,
+        expected_artifact_sha256=expected_artifact_sha256,
+        expected_source_sha256=expected_source_sha256,
+    )
+    source = _verify_source(
+        library_root,
+        target,
+        expected_source_sha256=expected_source_sha256,
+    )
+
+    current = _open_read_only(current_file)
+    backup = _open_read_only(backup_file)
+    try:
+        current_integrity = _integrity_check(current, "current DB")
+        backup_integrity = _integrity_check(backup, "backup DB")
+
+        current_lora_rows = int(
+            current.execute("SELECT COUNT(*) FROM lora").fetchone()[0]
+        )
+        backup_lora_rows = int(
+            backup.execute("SELECT COUNT(*) FROM lora").fetchone()[0]
+        )
+        current_block_rows = int(
+            current.execute("SELECT COUNT(*) FROM lora_block_weights").fetchone()[0]
+        )
+        backup_block_rows = int(
+            backup.execute("SELECT COUNT(*) FROM lora_block_weights").fetchone()[0]
+        )
+
+        _require_equal(
+            current_lora_rows,
+            expected_current_lora_rows,
+            "current lora row count",
+        )
+        _require_equal(
+            backup_lora_rows,
+            expected_backup_lora_rows,
+            "backup lora row count",
+        )
+        _require_equal(
+            current_block_rows,
+            expected_current_block_rows,
+            "current block row count",
+        )
+        _require_equal(
+            backup_block_rows,
+            expected_backup_block_rows,
+            "backup block row count",
+        )
+        _require_equal(current_lora_rows - backup_lora_rows, 1, "lora row delta")
+        _require_equal(
+            current_block_rows - backup_block_rows,
+            EXPECTED_BLOCK_COUNT,
+            "block row delta",
+        )
+
+        preserved_lora_rows = _verify_backup_rows_preserved(
+            backup,
+            current,
+            "lora",
+        )
+        preserved_block_rows = _verify_backup_rows_preserved(
+            backup,
+            current,
+            "lora_block_weights",
+        )
+
+        target_lora_id, target_block_rows = _verify_target_row(
+            current,
+            backup,
+            target,
+            expected_target_lora_id=expected_target_lora_id,
+        )
+
+        current_ids = {int(row[0]) for row in current.execute("SELECT id FROM lora")}
+        backup_ids = {int(row[0]) for row in backup.execute("SELECT id FROM lora")}
+        _require_equal(
+            current_ids - backup_ids,
+            {target_lora_id},
+            "new lora id set",
+        )
+
+        duplicates = _duplicate_stable_ids(current)
+        if duplicates:
+            raise Phase89mVerificationError(
+                f"duplicate stable IDs detected: {duplicates[:20]}"
+            )
+
+        with_stable_id = int(
+            current.execute(
+                """
+                SELECT COUNT(*)
+                FROM lora
+                WHERE stable_id IS NOT NULL
+                  AND TRIM(stable_id) <> ''
+                """
+            ).fetchone()[0]
+        )
+        _require_equal(
+            with_stable_id,
+            expected_current_lora_rows,
+            "rows with stable IDs",
+        )
+
+        damaged_current = int(
+            current.execute(
+                "SELECT COUNT(*) FROM lora WHERE stable_id = ?",
+                (DAMAGED_STABLE_ID,),
+            ).fetchone()[0]
+        )
+        damaged_backup = int(
+            backup.execute(
+                "SELECT COUNT(*) FROM lora WHERE stable_id = ?",
+                (DAMAGED_STABLE_ID,),
+            ).fetchone()[0]
+        )
+        _require_equal(damaged_current, 0, "damaged target current rows")
+        _require_equal(damaged_backup, 0, "damaged target backup rows")
+
+        orphan_blocks = int(
+            current.execute(
+                """
+                SELECT COUNT(*)
+                FROM lora_block_weights AS bw
+                LEFT JOIN lora AS l ON l.id = bw.lora_id
+                WHERE l.id IS NULL
+                """
+            ).fetchone()[0]
+        )
+        _require_equal(orphan_blocks, 0, "orphan block rows")
+    finally:
+        current.close()
+        backup.close()
+
+    result: dict[str, Any] = {
+        "phase": "8.9m",
+        "mode": "read-only post-apply verification and closeout",
+        "status": "verified",
+        "artifact_sha256": artifact_sha256,
+        "current_db_sha256": current_sha256,
+        "backup_db_sha256": backup_sha256,
+        "backup_path": str(backup_file),
+        "source_sha256": expected_source_sha256,
+        "source_path": str(source),
+        "database": {
+            "current_integrity": current_integrity,
+            "backup_integrity": backup_integrity,
+            "current_lora_rows": current_lora_rows,
+            "backup_lora_rows": backup_lora_rows,
+            "lora_row_delta": current_lora_rows - backup_lora_rows,
+            "current_block_rows": current_block_rows,
+            "backup_block_rows": backup_block_rows,
+            "block_row_delta": current_block_rows - backup_block_rows,
+            "rows_with_stable_ids": with_stable_id,
+            "duplicate_stable_ids": 0,
+            "orphan_block_rows": orphan_blocks,
+            "preserved_preexisting_lora_rows": preserved_lora_rows,
+            "preserved_preexisting_block_rows": preserved_block_rows,
+        },
+        "target": {
+            "stable_id": EXPECTED_STABLE_ID,
+            "lora_id": target_lora_id,
+            "model_family": "Flux 2",
+            "block_layout": EXPECTED_LAYOUT,
+            "verified_block_rows": target_block_rows,
+            "global_projection_tensors_preserved_in_artifact": (
+                EXPECTED_GLOBAL_TENSOR_COUNT
+            ),
+        },
+        "quarantine": {
+            "stable_id": DAMAGED_STABLE_ID,
+            "current_rows": damaged_current,
+            "backup_rows": damaged_backup,
+            "status": "absent and untouched",
+        },
+        "safety": {
+            "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+            "writes_database": False,
+            "creates_backup": False,
+            "runs_full_indexer": False,
+            "runs_reindex": False,
+            "discovers_library_files": False,
+            "opens_only_approved_source": True,
+            "touches_damaged_flux_target": False,
+        },
+    }
+    result["verification_sha256"] = canonical_sha256(result)
+    return result
+
+
+def verify_report_digest(report: Mapping[str, Any]) -> str:
+    stored = str(report.get("verification_sha256") or "")
+    unsigned = dict(report)
+    unsigned.pop("verification_sha256", None)
+    calculated = canonical_sha256(unsigned)
+    if stored != calculated:
+        raise Phase89mVerificationError(
+            f"verification report digest mismatch: "
+            f"stored {stored}, calculated {calculated}"
+        )
+    return calculated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read-only Phase 8.9m post-apply verification and closeout"
+    )
+    parser.add_argument("--artifact", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--backup", required=True)
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--json")
+    args = parser.parse_args()
+
+    result = verify_phase89m_closeout(
+        artifact_path=args.artifact,
+        current_db_path=args.db,
+        backup_db_path=args.backup,
+        library_root=args.root,
+    )
+    verify_report_digest(result)
+
+    print("=== Phase 8.9m post-apply verification and closeout ===")
+    print(f"Status                       : {result['status']}")
+    print(f"Verification SHA-256          : {result['verification_sha256']}")
+    print(f"Current DB SHA-256            : {result['current_db_sha256']}")
+    print(f"Backup DB SHA-256             : {result['backup_db_sha256']}")
+    print(f"Current LoRA rows             : {result['database']['current_lora_rows']}")
+    print(f"Backup LoRA rows              : {result['database']['backup_lora_rows']}")
+    print(f"Current block rows            : {result['database']['current_block_rows']}")
+    print(f"Backup block rows             : {result['database']['backup_block_rows']}")
+    print(
+        "Preserved existing LoRAs      : "
+        f"{result['database']['preserved_preexisting_lora_rows']}"
+    )
+    print(
+        "Preserved existing blocks     : "
+        f"{result['database']['preserved_preexisting_block_rows']}"
+    )
+    print(f"Verified target ID            : {result['target']['stable_id']}")
+    print(f"Verified target row ID        : {result['target']['lora_id']}")
+    print(f"Verified target blocks        : {result['target']['verified_block_rows']}")
+    print(f"Remaining quarantine          : {result['quarantine']['stable_id']}")
+    print(f"Quarantine status             : {result['quarantine']['status']}")
+    print("No database changes were made.")
+
+    if args.json:
+        output = Path(args.json).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(result, indent=2, sort_keys=True, allow_nan=False),
+            encoding="utf-8",
+        )
+        print(f"JSON verification written to: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Database/backend/tests/test_phase89m_post_apply_closeout.py
+++ b/Database/backend/tests/test_phase89m_post_apply_closeout.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+if str(BACKEND) not in sys.path:
+    sys.path.insert(0, str(BACKEND))
+
+from phase89k_flux2_layout_support import (
+    EXPECTED_GLOBAL_MODULES,
+    canonical_sha256,
+)
+from phase89m_post_apply_closeout import (
+    Phase89mVerificationError,
+    verify_phase89m_closeout,
+    verify_report_digest,
+)
+
+
+STABLE_ID = "FLX-STL-263"
+DAMAGED_ID = "FLX-BDY-071"
+RELATIVE_PATH = "FLUX/02 - Styles/aidmaMJ61Flux.2v0.5.safetensors"
+DB_FILE_PATH = f"/loras/{RELATIVE_PATH}"
+
+
+@dataclass
+class Fixture:
+    root: Path
+    source: Path
+    artifact_path: Path
+    artifact: dict[str, object]
+    current_db: Path
+    backup_db: Path
+    target_lora_id: int
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _create_schema(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE lora (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_path TEXT NOT NULL UNIQUE,
+            filename TEXT NOT NULL,
+            base_model_name TEXT,
+            base_model_code TEXT,
+            category_name TEXT,
+            category_code TEXT,
+            model_family TEXT,
+            lora_type TEXT,
+            rank INTEGER,
+            has_block_weights INTEGER NOT NULL DEFAULT 0,
+            block_layout TEXT,
+            clip_contributor INTEGER NOT NULL DEFAULT 0,
+            clip_tensor_count INTEGER NOT NULL DEFAULT -1,
+            last_modified REAL NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            stable_id TEXT
+        );
+        CREATE TABLE lora_block_weights (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lora_id INTEGER NOT NULL,
+            stable_id TEXT,
+            block_index INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            raw_strength REAL,
+            FOREIGN KEY (lora_id) REFERENCES lora(id) ON DELETE CASCADE
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_existing(
+    conn: sqlite3.Connection,
+    *,
+    file_path: str,
+    stable_id: str,
+    with_blocks: bool,
+) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO lora (
+            file_path, filename,
+            base_model_name, base_model_code,
+            category_name, category_code,
+            model_family, lora_type, rank,
+            has_block_weights, block_layout,
+            clip_contributor, clip_tensor_count,
+            last_modified, created_at, updated_at,
+            stable_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            file_path,
+            Path(file_path).name,
+            "Flux",
+            "FLX",
+            "People",
+            "PPL",
+            "Flux",
+            "Flux (UNet double+single blocks)" if with_blocks else None,
+            None,
+            1 if with_blocks else 0,
+            "flux_unet_57" if with_blocks else None,
+            0,
+            0,
+            100.0,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:00:00+00:00",
+            stable_id,
+        ),
+    )
+    lora_id = int(cursor.lastrowid)
+    if with_blocks:
+        conn.executemany(
+            """
+            INSERT INTO lora_block_weights (
+                lora_id, stable_id, block_index, weight, raw_strength
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (lora_id, stable_id, 0, 0.25, 1.0),
+                (lora_id, stable_id, 1, 0.5, 2.0),
+            ],
+        )
+    return lora_id
+
+
+def _artifact(source: Path) -> dict[str, object]:
+    source_sha = _sha256(source)
+    weights = [round(0.75 + (0.25 * index / 55), 6) for index in range(56)]
+    weights[-1] = 1.0
+    raw = [float(index + 1) for index in range(56)]
+
+    artifact: dict[str, object] = {
+        "phase": "8.9k",
+        "mode": "read-only sealed targeted Flux 2 artifact",
+        "phase89j_analysis_sha256": "j" * 64,
+        "target": {
+            "relative_path": RELATIVE_PATH,
+            "db_file_path": DB_FILE_PATH,
+            "filename": source.name,
+            "planned_stable_id": STABLE_ID,
+            "base_model_name": "Flux 2",
+            "base_model_code": "FLX",
+            "category_name": "Styles",
+            "category_code": "STL",
+            "source_size_bytes": source.stat().st_size,
+            "source_mtime": source.stat().st_mtime,
+            "source_sha256": source_sha,
+            "clip_contributor": False,
+            "clip_tensor_count": 0,
+            "tensor_key_count": 276,
+            "model_family": "Flux 2",
+            "lora_type": "Flux 2 (PEFT double+single blocks)",
+            "rank": 16,
+            "rank_values": [16],
+            "block_layout": "flux2_transformer_56",
+            "block_count": 56,
+            "block_weights": weights,
+            "raw_block_strengths": raw,
+            "observed_double_indices": list(range(8)),
+            "observed_single_indices": list(range(48)),
+            "missing_double_indices": [],
+            "missing_single_indices": [],
+            "extra_double_indices": [],
+            "extra_single_indices": [],
+            "block_module_count": 128,
+            "block_tensor_count": 256,
+            "global_module_count": 10,
+            "global_tensor_count": 20,
+            "global_modules": list(EXPECTED_GLOBAL_MODULES),
+            "unmatched_tensor_count": 0,
+            "unmatched_key_sample": [],
+            "warnings": [
+                "Global projection LoRA tensors are recorded separately and "
+                "excluded from per-block strengths"
+            ],
+            "blockers": [],
+            "ready_for_sealing": True,
+        },
+        "summary": {
+            "targets_analysed": 1,
+            "ready_for_later_controlled_apply": 1,
+            "block_rows": 56,
+            "global_projection_tensors": 20,
+            "damaged_flux_targets_untouched": 1,
+        },
+        "safety": {
+            "database_open_mode": "SQLite URI mode=ro plus PRAGMA query_only=ON",
+            "writes_database": False,
+            "creates_backup": False,
+            "runs_full_indexer": False,
+            "discovers_library_files": False,
+            "opens_only_phase89j_target": True,
+            "assigns_stable_ids": False,
+            "deletes_rows": False,
+            "touches_damaged_flux_target": False,
+            "contains_apply_mode": False,
+        },
+    }
+    artifact["artifact_sha256"] = canonical_sha256(artifact)
+    return artifact
+
+
+def _build_fixture(
+    tmp_path: Path,
+    *,
+    duplicate_backup_ids: bool = False,
+    damaged_in_backup: bool = False,
+) -> Fixture:
+    root = tmp_path / "loras"
+    source = root / Path(*RELATIVE_PATH.split("/"))
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"phase89m-flux2-source")
+
+    artifact = _artifact(source)
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(
+        __import__("json").dumps(artifact, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    backup_db = tmp_path / "backup.db"
+    current_db = tmp_path / "current.db"
+    _create_schema(backup_db)
+
+    conn = sqlite3.connect(backup_db)
+    first_id = "FLX-PPL-001"
+    second_id = first_id if duplicate_backup_ids else "FLX-PPL-002"
+    _insert_existing(
+        conn,
+        file_path="/loras/FLUX/01 - People/one.safetensors",
+        stable_id=first_id,
+        with_blocks=False,
+    )
+    _insert_existing(
+        conn,
+        file_path="/loras/FLUX/01 - People/two.safetensors",
+        stable_id=second_id,
+        with_blocks=True,
+    )
+    if damaged_in_backup:
+        _insert_existing(
+            conn,
+            file_path="/loras/FLUX/05 - Body/damaged.safetensors",
+            stable_id=DAMAGED_ID,
+            with_blocks=False,
+        )
+    conn.commit()
+    conn.close()
+
+    shutil.copy2(backup_db, current_db)
+
+    target = artifact["target"]
+    assert isinstance(target, dict)
+    conn = sqlite3.connect(current_db)
+    cursor = conn.execute(
+        """
+        INSERT INTO lora (
+            file_path, filename,
+            base_model_name, base_model_code,
+            category_name, category_code,
+            model_family, lora_type, rank,
+            has_block_weights, block_layout,
+            clip_contributor, clip_tensor_count,
+            last_modified, created_at, updated_at,
+            stable_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            target["db_file_path"],
+            target["filename"],
+            "Flux 2",
+            "FLX",
+            "Styles",
+            "STL",
+            "Flux 2",
+            "Flux 2 (PEFT double+single blocks)",
+            16,
+            1,
+            "flux2_transformer_56",
+            0,
+            0,
+            float(target["source_mtime"]),
+            "2026-07-29T22:18:23+00:00",
+            "2026-07-29T22:18:23+00:00",
+            STABLE_ID,
+        ),
+    )
+    target_lora_id = int(cursor.lastrowid)
+    conn.executemany(
+        """
+        INSERT INTO lora_block_weights (
+            lora_id, stable_id, block_index, weight, raw_strength
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                target_lora_id,
+                STABLE_ID,
+                index,
+                float(target["block_weights"][index]),
+                float(target["raw_block_strengths"][index]),
+            )
+            for index in range(56)
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    return Fixture(
+        root=root,
+        source=source,
+        artifact_path=artifact_path,
+        artifact=artifact,
+        current_db=current_db,
+        backup_db=backup_db,
+        target_lora_id=target_lora_id,
+    )
+
+
+def _counts(path: Path) -> tuple[int, int]:
+    conn = sqlite3.connect(path)
+    try:
+        return (
+            int(conn.execute("SELECT COUNT(*) FROM lora").fetchone()[0]),
+            int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM lora_block_weights"
+                ).fetchone()[0]
+            ),
+        )
+    finally:
+        conn.close()
+
+
+def _verify(fixture: Fixture, **overrides: object) -> dict[str, object]:
+    current_loras, current_blocks = _counts(fixture.current_db)
+    backup_loras, backup_blocks = _counts(fixture.backup_db)
+    artifact_sha = str(fixture.artifact["artifact_sha256"])
+    source_sha = str(fixture.artifact["target"]["source_sha256"])
+
+    values: dict[str, object] = {
+        "artifact_path": fixture.artifact_path,
+        "current_db_path": fixture.current_db,
+        "backup_db_path": fixture.backup_db,
+        "library_root": fixture.root,
+        "expected_artifact_sha256": artifact_sha,
+        "expected_current_db_sha256": _sha256(fixture.current_db),
+        "expected_backup_db_sha256": _sha256(fixture.backup_db),
+        "expected_backup_name": fixture.backup_db.name,
+        "expected_source_sha256": source_sha,
+        "expected_target_lora_id": fixture.target_lora_id,
+        "expected_current_lora_rows": current_loras,
+        "expected_backup_lora_rows": backup_loras,
+        "expected_current_block_rows": current_blocks,
+        "expected_backup_block_rows": backup_blocks,
+    }
+    values.update(overrides)
+    return verify_phase89m_closeout(**values)
+
+
+def test_complete_closeout_preserves_every_preexisting_row(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+    current_before = fixture.current_db.read_bytes()
+    backup_before = fixture.backup_db.read_bytes()
+
+    report = _verify(fixture)
+
+    assert report["status"] == "verified"
+    assert report["database"]["preserved_preexisting_lora_rows"] == 2
+    assert report["database"]["preserved_preexisting_block_rows"] == 2
+    assert report["target"]["verified_block_rows"] == 56
+    assert report["quarantine"]["status"] == "absent and untouched"
+    assert verify_report_digest(report) == report["verification_sha256"]
+    assert fixture.current_db.read_bytes() == current_before
+    assert fixture.backup_db.read_bytes() == backup_before
+
+
+def test_changed_preexisting_lora_row_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+    conn = sqlite3.connect(fixture.current_db)
+    conn.execute("UPDATE lora SET filename = 'changed.safetensors' WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(
+        Phase89mVerificationError,
+        match="pre-existing lora row changed",
+    ):
+        _verify(fixture)
+
+
+def test_changed_preexisting_block_row_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+    conn = sqlite3.connect(fixture.current_db)
+    conn.execute("UPDATE lora_block_weights SET weight = 0.9 WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(
+        Phase89mVerificationError,
+        match="pre-existing lora_block_weights row changed",
+    ):
+        _verify(fixture)
+
+
+def test_missing_new_block_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+    conn = sqlite3.connect(fixture.current_db)
+    conn.execute(
+        "DELETE FROM lora_block_weights WHERE lora_id = ? AND block_index = 55",
+        (fixture.target_lora_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(Phase89mVerificationError, match="block row delta"):
+        _verify(fixture)
+
+
+def test_duplicate_stable_ids_in_preserved_database_are_rejected(
+    tmp_path: Path,
+) -> None:
+    fixture = _build_fixture(tmp_path, duplicate_backup_ids=True)
+
+    with pytest.raises(Phase89mVerificationError, match="duplicate stable IDs"):
+        _verify(fixture)
+
+
+def test_damaged_target_leak_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path, damaged_in_backup=True)
+
+    with pytest.raises(
+        Phase89mVerificationError,
+        match="damaged target current rows",
+    ):
+        _verify(fixture)
+
+
+def test_source_drift_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+    fixture.source.write_bytes(b"source-drift-after-apply")
+
+    with pytest.raises(Phase89mVerificationError, match="source SHA-256"):
+        _verify(fixture)
+
+
+def test_wrong_current_database_digest_is_rejected(tmp_path: Path) -> None:
+    fixture = _build_fixture(tmp_path)
+
+    with pytest.raises(Phase89mVerificationError, match="current DB SHA-256"):
+        _verify(fixture, expected_current_db_sha256="0" * 64)

--- a/docs/phase89m-post-apply-closeout.md
+++ b/docs/phase89m-post-apply-closeout.md
@@ -1,0 +1,110 @@
+# Phase 8.9m post-apply verification and closeout
+
+Phase 8.9m provides a final read-only verification for the authorised Phase 8.9l insertion of `FLX-STL-263`.
+
+It does not perform another apply, scan, reindex, schema migration, relocation or restore.
+
+## Locked production evidence
+
+The verifier is pinned to the production state established on 29 July 2026:
+
+- merged tooling commit: `ba2fe7e21c28fa987c8406c561dc5f3ba276bbd7`
+- sealed Phase 8.9k artifact SHA-256: `adad9f9c3eb65bf0b2c0774e3c0c1508c43603ed3774c804f5ef49123d6a48df`
+- current database SHA-256: `6526505261ed62c79c433217161716e6d0bb9b286fb266867f9e6c87b1fa2357`
+- rollback backup SHA-256: `d732b2739cd2df278b104e325d17481413152d89776d8f1abdc59637bc86c79e`
+- rollback backup filename: `lora_master.phase89l.20260729T221823Z.adad9f9c3eb6.db`
+- source SHA-256: `c60c9a5de39da23b3b4f4dca48e3511faa1fe5a4987d4acbb0a04643a9a65be7`
+- stable ID: `FLX-STL-263`
+- inserted database row ID: `2834`
+- layout: `flux2_transformer_56`
+- current totals: 2,834 LoRA rows and 4,348 block rows
+- backup totals: 2,833 LoRA rows and 4,292 block rows
+
+## Verification depth
+
+`phase89m_post_apply_closeout.py` verifies more than aggregate totals.
+
+It performs the following read-only checks:
+
+1. validates the exact current database, backup, artifact and source SHA-256 values
+2. validates current and backup SQLite integrity
+3. verifies the exact current and backup row totals
+4. compares every one of the 2,833 pre-existing `lora` rows across every column
+5. compares every one of the 4,292 pre-existing `lora_block_weights` rows across every column
+6. requires the only new `lora` ID to be row `2834`
+7. verifies all Flux 2 metadata for `FLX-STL-263`
+8. verifies all 56 contiguous block rows against the sealed artifact weights and raw strengths
+9. verifies all 2,834 current rows have stable IDs
+10. rejects duplicate stable IDs
+11. rejects orphan block rows
+12. confirms `FLX-BDY-071` remains absent from both current and backup databases
+13. confirms the approved source file remains unchanged
+14. emits a canonical verification SHA-256
+
+## Global projection evidence
+
+The 20 global projection tensors remain preserved in the sealed Phase 8.9k artifact.
+
+The existing database schema has no honest storage field for those tensors. Phase 8.9m confirms the artifact still declares them and does not invent a schema extension or fold them into the 56 per-block weights.
+
+## Safety boundary
+
+Phase 8.9m:
+
+- opens both databases with SQLite URI `mode=ro`
+- enables `PRAGMA query_only = ON`
+- writes no database rows
+- creates no backup
+- has no apply mode
+- does not enumerate the library
+- opens only the approved Flux 2 source
+- does not touch the damaged source
+- writes only the optional JSON verification report
+
+## Bender validation
+
+From the repository root:
+
+```powershell
+& 'C:\Users\clink\miniconda3\python.exe' -m pytest `
+  Database\backend\tests\test_phase89m_post_apply_closeout.py `
+  -q
+
+& 'C:\Users\clink\miniconda3\python.exe' -m py_compile `
+  Database\backend\phase89m_post_apply_closeout.py
+```
+
+Expected: 8 tests passed and silent compilation.
+
+## Planned Nibbler run
+
+After review and merge, execute inside a temporary backend container:
+
+```bash
+sudo docker compose --env-file .env run --rm --no-deps -T backend \
+  python phase89m_post_apply_closeout.py \
+  --artifact /data/phase89k_flx_stl_263_flux2_artifact.json \
+  --db /data/lora_master.db \
+  --backup /data/backups/lora_master.phase89l.20260729T221823Z.adad9f9c3eb6.db \
+  --root /loras \
+  --json /data/phase89m_post_apply_closeout.json
+```
+
+The database SHA-256 and backup count must remain unchanged.
+
+## Completion condition
+
+Phase 8.9 is closed when the live Phase 8.9m report verifies:
+
+- current database integrity `ok`
+- backup integrity `ok`
+- 2,834 current LoRA rows
+- 4,348 current block rows
+- 2,833 preserved pre-existing LoRA rows
+- 4,292 preserved pre-existing block rows
+- one verified `FLX-STL-263` row with 56 verified blocks
+- zero duplicate stable IDs
+- zero orphan blocks
+- `FLX-BDY-071` absent and untouched
+- unchanged database SHA during verification
+- healthy live API and containers


### PR DESCRIPTION
## What changed

- Added a read-only Phase 8.9m closeout verifier for the completed `FLX-STL-263` Flux 2 insertion.
- Hard-locks the current database SHA-256 `6526505261ed62c79c433217161716e6d0bb9b286fb266867f9e6c87b1fa2357`.
- Hard-locks the verified rollback backup SHA-256 `d732b2739cd2df278b104e325d17481413152d89776d8f1abdc59637bc86c79e`.
- Hard-locks the sealed Phase 8.9k artifact and source digests.
- Verifies current and backup SQLite integrity.
- Compares every one of the 2,833 pre-existing `lora` rows across every column.
- Compares every one of the 4,292 pre-existing `lora_block_weights` rows across every column.
- Requires the only new LoRA ID to be row `2834`.
- Verifies the complete Flux 2 metadata and all 56 block rows against the sealed artifact.
- Verifies all 2,834 current LoRA rows have stable IDs.
- Rejects duplicate stable IDs and orphan block rows.
- Confirms `FLX-BDY-071` remains absent and untouched.
- Verifies the approved source file remains unchanged.
- Emits a canonical Phase 8.9m verification digest.
- Added eight focused tests and a closeout runbook.

## Safety boundary

- SQLite URI `mode=ro` plus `PRAGMA query_only = ON` for both databases.
- No inserts, updates or deletes.
- No backup creation.
- No apply mode.
- No scan, reindex or schema migration.
- No library enumeration.
- Opens only the approved Flux 2 source.
- Writes only the optional JSON verification report.

## Validation

Verified on Bender from the repository root:

```text
8 passed in 0.37s
python -m py_compile: passed silently
```